### PR TITLE
Keep transient feed gaps from blanking the radar

### DIFF
--- a/src/adsb_client.cpp
+++ b/src/adsb_client.cpp
@@ -29,12 +29,10 @@ void AdsbClient::begin(double homeLat, double homeLon, float rangeKm) {
 
 bool AdsbClient::poll(std::vector<Aircraft>& out) {
     if (WiFi.status() != WL_CONNECTED) return false;
-    // Prefer the primary host, and give it a quick second try before touching the fallback:
-    // the primary is reliable in practice, while the fallback can be slow to time out from
-    // some networks (turning one transient primary blip into a long no-data gap + amber HUD).
+    // Try each independent provider once. Retrying the primary immediately can violate its
+    // one-request-per-second limit and adds another full timeout to an already slow failure.
     if (fetchFrom(ADSB_PRIMARY_HOST, out)) return true;
-    if (fetchFrom(ADSB_PRIMARY_HOST, out)) return true;   // transient blip -> retry the healthy host
-    return fetchFrom(ADSB_FALLBACK_HOST, out);            // last resort
+    return fetchFrom(ADSB_FALLBACK_HOST, out);
 }
 
 bool AdsbClient::fetchFrom(const char* host, std::vector<Aircraft>& out) {
@@ -74,7 +72,10 @@ bool AdsbClient::fetchFrom(const char* host, std::vector<Aircraft>& out) {
     DeserializationError err = deserializeJson(doc, http.getStream(),
                                                DeserializationOption::Filter(filter));
     http.end();
-    if (err) return false;
+    if (err) {
+        Serial.printf("[adsb] JSON parse failed (%s): %s\n", host, err.c_str());
+        return false;
+    }
 
     JsonArrayConst arr = doc["ac"].as<JsonArrayConst>();
     if (arr.isNull()) arr = doc["aircraft"].as<JsonArrayConst>();

--- a/src/adsb_client.cpp
+++ b/src/adsb_client.cpp
@@ -23,6 +23,29 @@ struct PsramJsonAllocator : ArduinoJson::Allocator {
 };
 static PsramJsonAllocator s_jsonPsram;
 
+// NetworkClient::readBytes() treats a transient negative TLS read as end-of-input,
+// which makes ArduinoJson intermittently report IncompleteInput. Deliberately wrap
+// the client without overriding readBytes(): Stream's timed byte reader retries
+// temporary no-data reads until the configured timeout.
+class ReliableJsonStream : public Stream {
+public:
+    explicit ReliableJsonStream(Stream& source) : _source(source) {}
+    int available() override { return _source.available(); }
+    int read() override {
+        const int value = _source.read();
+        if (value >= 0) ++_bytesRead;
+        return value;
+    }
+    int peek() override { return _source.peek(); }
+    void flush() override { _source.flush(); }
+    size_t write(uint8_t) override { return 0; }
+    size_t bytesRead() const { return _bytesRead; }
+
+private:
+    Stream& _source;
+    size_t _bytesRead = 0;
+};
+
 void AdsbClient::begin(double homeLat, double homeLon, float rangeKm) {
     _lat = homeLat; _lon = homeLon; _rangeKm = rangeKm;
 }
@@ -69,13 +92,19 @@ bool AdsbClient::fetchFrom(const char* host, std::vector<Aircraft>& out) {
             filter[k][0][f] = true;
 
     JsonDocument doc(&s_jsonPsram);
-    DeserializationError err = deserializeJson(doc, http.getStream(),
+    const int expectedBytes = http.getSize();
+    NetworkClient& responseStream = http.getStream();
+    ReliableJsonStream jsonStream(responseStream);
+    DeserializationError err = deserializeJson(doc, jsonStream,
                                                DeserializationOption::Filter(filter));
-    http.end();
     if (err) {
-        Serial.printf("[adsb] JSON parse failed (%s): %s\n", host, err.c_str());
+        Serial.printf("[adsb] JSON parse failed (%s): %s; expected=%d read=%u available=%d connected=%d\n",
+                      host, err.c_str(), expectedBytes, (unsigned)jsonStream.bytesRead(),
+                      responseStream.available(), responseStream.connected());
+        http.end();
         return false;
     }
+    http.end();
 
     JsonArrayConst arr = doc["ac"].as<JsonArrayConst>();
     if (arr.isNull()) arr = doc["aircraft"].as<JsonArrayConst>();

--- a/src/config.h
+++ b/src/config.h
@@ -17,7 +17,7 @@ static const float RANGE_STEPS_KM[] = {10.0f, 20.0f, 30.0f, 50.0f, 100.0f};
 #define POLL_INTERVAL_MS    2000           // be gentle with the free API (>=1000)
 #define POLL_INTERVAL_BATTERY_MS 5000      // slower polling when running on battery
 #define MOTION_INTERP       1              // 1 = glyphs glide between polls; 0 = snap to new pos
-#define AC_STALE_MS         15000          // drop aircraft not refreshed in this long
+#define AC_STALE_MS         15000          // keep the last contacts through brief empty feed responses
 
 // ---------- Screen (CO5300 AMOLED) ----------
 #define SCREEN_W            466

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include "aircraft.h"
 #include "geo.h"
 #include "adsb_client.h"
+#include "snapshot_gate.h"
 #include "route.h"
 #include "route_client.h"
 #include "photo.h"
@@ -88,6 +89,8 @@ static const int TZOPTS_N = sizeof(TZOPTS) / sizeof(TZOPTS[0]);
 // ---- networking task (core 0): fetch + parse, never touches the display ----
 static void adsb_task(void*) {
     std::vector<Aircraft> fresh;
+    AircraftSnapshotGate snapshotGate;
+    bool retainingEmptySnapshot = false;
     bool wasConnected = false;
     uint32_t lastPoll = 0;
     uint32_t lastFeedOk = millis();          // self-heal: time of last good (or no-WiFi) poll
@@ -125,18 +128,33 @@ static void adsb_task(void*) {
             if (lastPoll == 0 || nowMs - lastPoll >= pollInterval) {  // aircraft feed
                 lastPoll = nowMs;
                 static int failCount = 0;
-                // poll() flips to the alternate host on failure, so consecutive polls already
-                // alternate hosts; a single transient miss is absorbed by the failCount window.
+                // poll() tries the fallback provider after a primary failure; keep the HUD
+                // healthy through isolated misses and warn only after a sustained outage.
                 if (g_adsb.poll(fresh)) {
                     Serial.printf("[adsb] fetched %u aircraft\n", (unsigned)fresh.size());
                     failCount = 0;
                     g_feedOk = true;
-                    lastFeedOk = nowMs;
-                    g_lastFeedOkMs = nowMs;          // HUD: mark data as fresh
-                    if (xSemaphoreTake(g_ac_mutex, pdMS_TO_TICKS(200)) == pdTRUE) {
-                        g_aircraft.swap(fresh);   // O(1) handoff: no per-Aircraft String copies under the lock
-                        g_acDirty = true;
-                        xSemaphoreGive(g_ac_mutex);
+                    const uint32_t receivedMs = millis();
+                    lastFeedOk = receivedMs;
+                    g_lastFeedOkMs = receivedMs;      // HUD: mark data as fresh
+
+                    const bool publish = snapshotGate.shouldPublish(
+                        !fresh.empty(), receivedMs, AC_STALE_MS);
+                    if (!publish) {
+                        if (!retainingEmptySnapshot) {
+                            Serial.printf("[adsb] empty snapshot; retaining contacts for %u ms\n",
+                                          (unsigned)AC_STALE_MS);
+                            retainingEmptySnapshot = true;
+                        }
+                    } else {
+                        if (retainingEmptySnapshot && fresh.empty())
+                            Serial.println("[adsb] empty snapshot persisted; clearing stale contacts");
+                        retainingEmptySnapshot = false;
+                        if (xSemaphoreTake(g_ac_mutex, pdMS_TO_TICKS(200)) == pdTRUE) {
+                            g_aircraft.swap(fresh);   // O(1) handoff: no per-Aircraft String copies under the lock
+                            g_acDirty = true;
+                            xSemaphoreGive(g_ac_mutex);
+                        }
                     }
                 } else {
                     Serial.println("[adsb] poll failed");

--- a/src/snapshot_gate.h
+++ b/src/snapshot_gate.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdint.h>
+
+// Prevent a single valid-but-empty feed response from clearing the radar.
+// Poll failures never reach this gate, so the last rendered snapshot is also
+// retained while the network is unavailable.
+class AircraftSnapshotGate {
+public:
+    bool shouldPublish(bool hasAircraft, uint32_t nowMs, uint32_t emptyGraceMs) {
+        if (hasAircraft) {
+            _emptyPending = false;
+            return true;
+        }
+
+        if (!_emptyPending) {
+            _emptyPending = true;
+            _emptySinceMs = nowMs;
+        }
+        return (uint32_t)(nowMs - _emptySinceMs) >= emptyGraceMs;
+    }
+
+private:
+    bool _emptyPending = false;
+    uint32_t _emptySinceMs = 0;
+};

--- a/tests/snapshot_gate_test.cpp
+++ b/tests/snapshot_gate_test.cpp
@@ -1,0 +1,24 @@
+#include "snapshot_gate.h"
+
+#include <assert.h>
+#include <stdint.h>
+
+int main() {
+    AircraftSnapshotGate gate;
+
+    assert(gate.shouldPublish(true, 1000, 15000));
+    assert(!gate.shouldPublish(false, 2000, 15000));
+    assert(!gate.shouldPublish(false, 16999, 15000));
+    assert(gate.shouldPublish(false, 17000, 15000));
+
+    // A recovered non-empty snapshot resets the empty-response grace period.
+    assert(gate.shouldPublish(true, 18000, 15000));
+    assert(!gate.shouldPublish(false, 19000, 15000));
+    assert(!gate.shouldPublish(false, 20000, 15000));
+
+    // Unsigned subtraction keeps expiry correct across millis() rollover.
+    AircraftSnapshotGate rolloverGate;
+    assert(!rolloverGate.shouldPublish(false, UINT32_MAX - 5, 10));
+    assert(!rolloverGate.shouldPublish(false, 3, 10));
+    assert(rolloverGate.shouldPublish(false, 4, 10));
+}


### PR DESCRIPTION
## Summary

- parse HTTPS responses through a `Stream` adapter that retries transient TLS no-data reads instead of truncating JSON
- retain the last aircraft snapshot for `AC_STALE_MS` when the feed briefly returns a valid empty array
- clear stale contacts only after empty responses persist for the full 15-second grace period
- remove the immediate retry against airplanes.live and fail over directly to adsb.lol
- include response byte diagnostics if JSON parsing still fails
- add a portable regression test for empty-response recovery, expiry, and `millis()` rollover

## Why

Physical-device logs showed repeated `IncompleteInput` failures from both providers followed by fallback `HTTP 429` responses. An A/B firmware test isolated the primary cause: passing `NetworkClient` directly to ArduinoJson invokes its optimized `readBytes()` path, which treats a transient negative TLS read as end-of-input. Wrapping it as a plain `Stream` uses the timed byte reader and allows the response to complete.

Separately, a single successful response containing zero aircraft previously replaced the live snapshot immediately, making the display appear blank during transient upstream gaps.

## Verification

- inverse physical-device A/B reproduced `IncompleteInput` and `HTTP 429` on the direct `NetworkClient` path
- fixed firmware polled continuously for over 70 seconds at 8-10 aircraft with zero parse errors, rate limits, or poll failures
- `c++ -std=c++17 -Wall -Wextra -Werror -Isrc tests/snapshot_gate_test.cpp -o /tmp/capsule-radar-snapshot-gate-test && /tmp/capsule-radar-snapshot-gate-test`
- `pio run -e native`
- `pio run -e esp32-s3-amoled-175`
- physical ESP32-S3 flash completed successfully
- `git diff --check`

ESP32-S3 build result: RAM 37.9%, flash 43.9%.

## Remaining validation

A long-duration hardware soak beyond the observed validation window has not yet been run.
