### PR TITLE
fixed lv_conf.h missing bug in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ build_flags =
     -DCORE_DEBUG_LEVEL=0              ; silence Arduino library [E] spam (Wire I2C -1/263, ssl_client);
                                       ;   our own Serial.printf [adsb]/[gps]/[wifi] logs are unaffected
     -DLV_CONF_INCLUDE_SIMPLE          ; LVGL does #include "lv_conf.h"
-    -I${PROJECT_DIR}/include          ; ...and finds it here (PIO's auto include/ is not on the LIBRARY path)
+    -I"${PROJECT_DIR}/include"        ; ...and finds it here (PIO's auto include/ is not on the LIBRARY path)
     -std=gnu++17
 build_unflags = -std=gnu++11
 
@@ -66,7 +66,7 @@ build_src_filter = -<*> +<radar_view.cpp> +<ui.cpp> +<route.cpp> +<photo.cpp> +<
 build_flags =
     !sdl2-config --cflags --libs      ; SDL2 include/lib flags (Homebrew sdl2)
     -DLV_CONF_INCLUDE_SIMPLE
-    -I${PROJECT_DIR}/include
+    -I"${PROJECT_DIR}/include"
     -DLV_LOG_PRINTF=1
     -std=gnu++17
 lib_deps =


### PR DESCRIPTION
quotation marks are needed for the file path, otherwise the build can fail due to not being able to locate lv_conf.h