### PR TITLE
Add arbitrary per-degree display rotation

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -13,6 +13,8 @@
 #include <Arduino_GFX_Library.h>
 #include <lvgl.h>
 #include <esp_heap_caps.h>
+#include <math.h>
+#include <string.h>
 
 // --- Arduino_GFX panel -------------------------------------------------------
 // Typed as Arduino_CO5300* (not Arduino_GFX*) so setBrightness() — declared on
@@ -31,8 +33,94 @@ static lv_color_t        *s_buf2 = nullptr;
 static volatile uint32_t s_frameCount = 0;   // rendered frames (last-flush), for FPS measurement
 uint32_t display_frames() { return s_frameCount; }
 
-static volatile uint8_t s_rot = 0;           // display rotation: 0/1/2/3 = 0°/90°/180°/270°
-static lv_color_t *s_rotBuf = nullptr;       // PSRAM scratch for 90/270° transpose (see begin())
+static volatile uint16_t s_rot = 0;          // clockwise display rotation, 0..359 degrees
+static float      s_rotCos = 1.0f;
+static float      s_rotSin = 0.0f;
+static int32_t    s_rotCosQ16 = 65536;       // fixed-point values used in the per-pixel hot path
+static int32_t    s_rotSinQ16 = 0;
+static lv_color_t *s_rotBuf = nullptr;       // PSRAM scratch for rotated output (see begin())
+static lv_color_t *s_frameBuf = nullptr;     // full logical framebuffer for arbitrary-angle sampling
+
+static void draw_block(int16_t x, int16_t y, lv_color_t *pixels, uint16_t w, uint16_t h) {
+#if (LV_COLOR_16_SWAP != 0)
+    s_gfx->draw16bitBeRGBBitmap(x, y, (uint16_t *)pixels, w, h);
+#else
+    s_gfx->draw16bitRGBBitmap(x, y, (uint16_t *)pixels, w, h);
+#endif
+}
+
+// Render the physical bounding box affected by a logical dirty rectangle. Sampling
+// from the full logical framebuffer avoids gaps/overdraw artifacts that forward-mapping
+// individual source pixels would create at non-cardinal angles.
+static void flush_arbitrary(const lv_area_t *area) {
+    const float cx = (SCREEN_W - 1) * 0.5f;
+    const float cy = (SCREEN_H - 1) * 0.5f;
+    const float xs[4] = {(float)area->x1, (float)area->x2, (float)area->x2, (float)area->x1};
+    const float ys[4] = {(float)area->y1, (float)area->y1, (float)area->y2, (float)area->y2};
+    float minX = (float)SCREEN_W, minY = (float)SCREEN_H, maxX = -1.0f, maxY = -1.0f;
+    for (int i = 0; i < 4; ++i) {
+        const float rx = xs[i] - cx;
+        const float ry = ys[i] - cy;
+        const float dx = cx + s_rotCos * rx - s_rotSin * ry;
+        const float dy = cy + s_rotSin * rx + s_rotCos * ry;
+        if (dx < minX) minX = dx;
+        if (dx > maxX) maxX = dx;
+        if (dy < minY) minY = dy;
+        if (dy > maxY) maxY = dy;
+    }
+
+    // Include nearest-neighbour edge pixels and preserve the panel's required 2-pixel
+    // alignment (even start, odd end) in both axes.
+    int x1 = (int)floorf(minX) - 1;
+    int y1 = (int)floorf(minY) - 1;
+    int x2 = (int)ceilf(maxX) + 1;
+    int y2 = (int)ceilf(maxY) + 1;
+    if (x1 < 0) x1 = 0;
+    if (y1 < 0) y1 = 0;
+    x1 &= ~1;
+    y1 &= ~1;
+    x2 |= 1;
+    y2 |= 1;
+    if (x2 >= SCREEN_W) x2 = SCREEN_W - 1;
+    if (y2 >= SCREEN_H) y2 = SCREEN_H - 1;
+    if (x1 > x2 || y1 > y2) return;
+
+    const int outW = x2 - x1 + 1;
+    const lv_color_t black = lv_color_black();
+    const int64_t centerX2Q16 = (int64_t)(SCREEN_W - 1) * 65536;
+    const int64_t centerY2Q16 = (int64_t)(SCREEN_H - 1) * 65536;
+    const int32_t stepX = s_rotCosQ16 * 2;
+    const int32_t stepY = -s_rotSinQ16 * 2;
+
+    // Batch scanlines while keeping every physical write 2-pixel aligned. Fewer QSPI
+    // transactions matter here because an arbitrary-angle dirty box can be fairly large.
+    for (int dy = y1; dy <= y2; ) {
+        int rows = y2 - dy + 1;
+        if (rows > LVGL_BUF_LINES) rows = LVGL_BUF_LINES;
+        rows &= ~1;
+        for (int row = 0; row < rows; ++row) {
+            const int py = dy + row;
+            const int relX2 = 2 * x1 - (SCREEN_W - 1);
+            const int relY2 = 2 * py - (SCREEN_H - 1);
+            int64_t srcX2Q16 = centerX2Q16 + (int64_t)s_rotCosQ16 * relX2
+                                                + (int64_t)s_rotSinQ16 * relY2;
+            int64_t srcY2Q16 = centerY2Q16 - (int64_t)s_rotSinQ16 * relX2
+                                                + (int64_t)s_rotCosQ16 * relY2;
+            lv_color_t *out = s_rotBuf + row * outW;
+            for (int dx = 0; dx < outW; ++dx) {
+                const int sx = (int)((srcX2Q16 + 65536) >> 17);
+                const int sy = (int)((srcY2Q16 + 65536) >> 17);
+                out[dx] = (sx >= 0 && sx < SCREEN_W && sy >= 0 && sy < SCREEN_H)
+                            ? s_frameBuf[sy * SCREEN_W + sx]
+                            : black;
+                srcX2Q16 += stepX;
+                srcY2Q16 += stepY;
+            }
+        }
+        draw_block((int16_t)x1, (int16_t)dy, s_rotBuf, (uint16_t)outW, (uint16_t)rows);
+        dy += rows;
+    }
+}
 
 // LVGL -> panel, applying the chosen rotation while pushing.
 //   0°   : straight through.
@@ -40,20 +128,36 @@ static lv_color_t *s_rotBuf = nullptr;       // PSRAM scratch for 90/270° trans
 //   90°/270° : the block transposes (w<->h), so it can't be reversed in place; copy it
 //              rotated into a PSRAM scratch buffer. That buffer MUST live in PSRAM — an
 //              internal-RAM one starves the mbedTLS handshake and kills the ADS-B feed.
+//   other: update the logical framebuffer and inverse-sample the rotated dirty bounds.
 static void flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *px) {
     const int w = (int)(area->x2 - area->x1 + 1);
     const int h = (int)(area->y2 - area->y1 + 1);
+    if (s_frameBuf) {
+        for (int row = 0; row < h; ++row) {
+            memcpy(s_frameBuf + (area->y1 + row) * SCREEN_W + area->x1,
+                   px + row * w, (size_t)w * sizeof(lv_color_t));
+        }
+    }
+
+    const uint16_t angle = s_rot;
+    if (angle != 0 && angle != 90 && angle != 180 && angle != 270 && s_frameBuf && s_rotBuf) {
+        flush_arbitrary(area);
+        if (lv_disp_flush_is_last(drv)) s_frameCount++;
+        lv_disp_flush_ready(drv);
+        return;
+    }
+
     lv_color_t *out = px;
     int16_t  dx = area->x1, dy = area->y1;
     uint16_t dw = (uint16_t)w, dh = (uint16_t)h;
 
-    switch (s_rot) {
-        case 2:  // 180°
+    switch (angle) {
+        case 180:
             for (int i = 0, j = w * h - 1; i < j; ++i, --j) { lv_color_t t = px[i]; px[i] = px[j]; px[j] = t; }
             dx = (int16_t)(SCREEN_W - 1 - area->x2);
             dy = (int16_t)(SCREEN_H - 1 - area->y2);
             break;
-        case 1:  // 90° CW
+        case 90:
             if (s_rotBuf) {
                 for (int j = 0; j < h; ++j)
                     for (int i = 0; i < w; ++i)
@@ -62,7 +166,7 @@ static void flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *px) 
                 dx = (int16_t)(SCREEN_H - 1 - area->y2); dy = area->x1;
             }
             break;
-        case 3:  // 270° CW
+        case 270:
             if (s_rotBuf) {
                 for (int j = 0; j < h; ++j)
                     for (int i = 0; i < w; ++i)
@@ -73,11 +177,7 @@ static void flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *px) 
             break;
         default: break;  // 0°
     }
-#if (LV_COLOR_16_SWAP != 0)
-    s_gfx->draw16bitBeRGBBitmap(dx, dy, (uint16_t *)out, dw, dh);
-#else
-    s_gfx->draw16bitRGBBitmap(dx, dy, (uint16_t *)out, dw, dh);
-#endif
+    draw_block(dx, dy, out, dw, dh);
     if (lv_disp_flush_is_last(drv)) s_frameCount++;
     lv_disp_flush_ready(drv);
 }
@@ -97,12 +197,30 @@ static void touch_read_cb(lv_indev_drv_t *drv, lv_indev_data_t *data) {
     (void)drv;
     uint16_t x, y;
     if (touch_read(&x, &y)) {
-        uint16_t lx = x, ly = y;                          // map physical touch -> logical (inverse rotation)
-        switch (s_rot) {
-            case 1: lx = y;                            ly = (uint16_t)(SCREEN_H - 1 - x); break;
-            case 2: lx = (uint16_t)(SCREEN_W - 1 - x); ly = (uint16_t)(SCREEN_H - 1 - y); break;
-            case 3: lx = (uint16_t)(SCREEN_W - 1 - y); ly = x;                            break;
-            default: break;
+        int lx = x, ly = y;                              // physical touch -> logical (inverse rotation)
+        const uint16_t angle = s_rot;
+        switch (angle) {
+            case 90:  lx = y;                        ly = SCREEN_H - 1 - x; break;
+            case 180: lx = SCREEN_W - 1 - x;         ly = SCREEN_H - 1 - y; break;
+            case 270: lx = SCREEN_W - 1 - y;         ly = x; break;
+            default:
+                if (angle != 0) {
+                    const int relX2 = 2 * (int)x - (SCREEN_W - 1);
+                    const int relY2 = 2 * (int)y - (SCREEN_H - 1);
+                    const int64_t sx2q = (int64_t)(SCREEN_W - 1) * 65536
+                                       + (int64_t)s_rotCosQ16 * relX2
+                                       + (int64_t)s_rotSinQ16 * relY2;
+                    const int64_t sy2q = (int64_t)(SCREEN_H - 1) * 65536
+                                       - (int64_t)s_rotSinQ16 * relX2
+                                       + (int64_t)s_rotCosQ16 * relY2;
+                    lx = (int)((sx2q + 65536) >> 17);
+                    ly = (int)((sy2q + 65536) >> 17);
+                }
+                break;
+        }
+        if (lx < 0 || lx >= SCREEN_W || ly < 0 || ly >= SCREEN_H) {
+            data->state = LV_INDEV_STATE_RELEASED;        // black corners are outside the logical UI
+            return;
         }
         data->point.x = (lv_coord_t)lx;
         data->point.y = (lv_coord_t)ly;
@@ -143,11 +261,15 @@ bool begin() {
     }
     lv_disp_draw_buf_init(&s_draw_buf, s_buf1, s_buf2, buf_px);
 
-    // Scratch target for 90/270° rotation (the block transposes, so it can't rotate in
-    // place). Deliberately in PSRAM: an internal-RAM buffer here would eat the contiguous
-    // block the TLS handshake needs and break the ADS-B feed. NULL is fine (rotation just
-    // falls back to un-rotated for 90/270° if PSRAM is exhausted).
+    // Rotation buffers live in PSRAM so the internal contiguous block needed by TLS remains
+    // available. The full logical framebuffer makes inverse sampling at arbitrary angles
+    // possible without holes; the smaller scratch holds transposed blocks or output batches.
     s_rotBuf = (lv_color_t *)heap_caps_malloc(buf_px * sizeof(lv_color_t), MALLOC_CAP_SPIRAM);
+    s_frameBuf = (lv_color_t *)heap_caps_calloc((size_t)SCREEN_W * SCREEN_H,
+                                                sizeof(lv_color_t), MALLOC_CAP_SPIRAM);
+    if (!s_rotBuf || !s_frameBuf) {
+        Serial.println("[display] WARNING: rotation buffer allocation failed; arbitrary angles unavailable");
+    }
 
     lv_disp_drv_init(&s_disp_drv);
     s_disp_drv.hor_res  = SCREEN_W;
@@ -176,12 +298,29 @@ void loop() { lv_timer_handler(); }
 
 void setBrightness(uint8_t v) { if (s_gfx) s_gfx->setBrightness(v); }
 
-void setRotation(uint8_t quarters) {
-    s_rot = (uint8_t)(quarters & 3);   // 0..3 = 0°/90°/180°/270°
+void setRotation(uint16_t degrees) {
+    uint16_t normalized = (uint16_t)(degrees % 360);
+    if ((normalized == 90 || normalized == 270) && !s_rotBuf) {
+        Serial.println("[display] quarter-turn rotation unavailable without the PSRAM scratch buffer");
+        normalized = 0;
+    }
+    if (normalized != 0 && normalized != 90 && normalized != 180 && normalized != 270
+        && (!s_frameBuf || !s_rotBuf)) {
+        Serial.println("[display] arbitrary rotation unavailable without both PSRAM buffers");
+        normalized = 0;
+    }
+    if (normalized == s_rot) return;
+    const float radians = normalized * ((float)M_PI / 180.0f);
+    s_rotCos = cosf(radians);
+    s_rotSin = sinf(radians);
+    s_rotCosQ16 = (int32_t)lroundf(s_rotCos * 65536.0f);
+    s_rotSinQ16 = (int32_t)lroundf(s_rotSin * 65536.0f);
+    s_rot = normalized;
+    if (s_gfx) s_gfx->fillScreen(RGB565_BLACK);  // clear pixels no longer covered after an angle change
     lv_obj_t *scr = lv_scr_act();
     if (scr) lv_obj_invalidate(scr);   // full repaint in the new orientation
 }
-uint8_t rotation() { return s_rot; }
+uint16_t rotation() { return s_rot; }
 
 uint32_t inactiveMs() { return lv_disp_get_inactive_time(NULL); }
 

--- a/src/display.h
+++ b/src/display.h
@@ -19,11 +19,12 @@ void setBrightness(uint8_t v);
 // ms since the last touch (LVGL inactivity timer) — for idle auto-dim.
 uint32_t inactiveMs();
 
-// Rotate the whole UI in 90° steps (0/1/2/3 = 0°/90°/180°/270°), e.g. to mount with the
-// USB-C port on any side. Applied in the flush (180° in place; 90/270° via a PSRAM
-// scratch buffer) and mirrored on touch input.
-void setRotation(uint8_t quarters);
-uint8_t rotation();
+// Rotate the whole UI clockwise by an arbitrary number of degrees (normalized to
+// 0..359), e.g. to compensate for any enclosure/mounting angle. Cardinal rotations
+// keep their optimized flush paths; other angles use a PSRAM framebuffer. Touch input
+// is transformed back into the same logical coordinate space.
+void setRotation(uint16_t degrees);
+uint16_t rotation();
 
 } // namespace display
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ static bool                  g_showAirports = true;                  // airport 
 static bool                  g_hideGround   = false;                 // skip on-ground aircraft in the feed (web/NVS)
 static int                   g_minAltFt     = 0;                     // only show aircraft above this altitude, ft (0 = off) (web/NVS)
 static bool                  g_milOnly      = false;                 // only show military-flagged aircraft (web/NVS)
-static int                   g_rotation = 0;                         // display rotation 0/1/2/3 = 0/90/180/270 (web/NVS)
+static int                   g_rotation = 0;                         // clockwise display rotation, 0..359° (web/NVS)
 static bool                  g_useGps = false;                       // auto-set home from the LC76G GPS (-G variant) (web/NVS)
 static int                   g_trailLen = 2;                         // aircraft trails 0=off 1=short 2=med 3=long (web/NVS)
 static int                   g_maxAc = 20;                           // max aircraft drawn on the scope (web/NVS)
@@ -325,13 +325,6 @@ static void handleRoot() {
         snprintf(o, sizeof(o), "<option value=%d%s>%s</option>", i, i == g_units ? " selected" : "", unames[i]);
         uopts += o;
     }
-    const char *rnames[] = {"0\xc2\xb0 (default)", "90\xc2\xb0", "180\xc2\xb0", "270\xc2\xb0"};
-    String rotopts;
-    for (int i = 0; i < 4; ++i) {
-        char o[64];
-        snprintf(o, sizeof(o), "<option value=%d%s>%s</option>", i, i == g_rotation ? " selected" : "", rnames[i]);
-        rotopts += o;
-    }
     const char *tlnames[] = {"Off", "Short", "Medium", "Long"};
     String tlopts;
     for (int i = 0; i < 4; ++i) {
@@ -446,7 +439,8 @@ static void handleRoot() {
         "<label><input type=checkbox class=ck %s onchange='mo(this.checked)'>Military aircraft only</label>"
         "<label>Aircraft trails</label><select onchange='tl(this.value)'>%s</select>"
         "<label>Max aircraft on screen</label><select onchange='mx(this.value)'>%s</select>"
-        "<label>Screen rotation (USB-C position)</label><select onchange='ro(this.value)'>%s</select>"
+        "<label>Screen rotation (degrees clockwise)</label>"
+        "<input type=number min=0 max=359 step=1 value='%d' onchange='ro(this.value)'>"
         "<label>Units</label><select onchange='u(this.value)'>%s</select></div>"
         "<div class=card><div class=t>Sound</div>"
         "<label>Volume</label>"
@@ -496,7 +490,7 @@ static void handleRoot() {
         tzopts.c_str(),
         g_brightnessDay, iopts.c_str(), g_showSweep ? "checked" : "",
         g_showAirports ? "checked" : "", g_hideGround ? "checked" : "", maopts.c_str(), g_milOnly ? "checked" : "",
-        tlopts.c_str(), mxopts.c_str(), rotopts.c_str(), uopts.c_str(),
+        tlopts.c_str(), mxopts.c_str(), g_rotation, uopts.c_str(),
         g_volume, g_muted ? "checked" : "", aopts.c_str(), popts.c_str(),
         g_settings.homeLat, g_settings.homeLon, (g_tz == TZ_STR ? 0 : 1));
     g_web.send(200, "text/html", buf);
@@ -722,14 +716,15 @@ static void handleGround() {   // hide/show on-ground aircraft (applies from the
     g_web.send(200, "text/plain", "ok");
 }
 
-static void handleRotate() {   // display rotation 0/90/180/270 for any USB-C orientation (live)
+static void handleRotate() {   // arbitrary clockwise display rotation, applied live
     if (g_web.hasArg("v")) {
-        g_rotation = constrain((int)g_web.arg("v").toInt(), 0, 3);
-        display::setRotation((uint8_t)g_rotation);
+        g_rotation = constrain((int)g_web.arg("v").toInt(), 0, 359);
+        display::setRotation((uint16_t)g_rotation);
+        g_rotation = display::rotation();
         if (g_web.hasArg("save")) {
             Preferences p;
             p.begin("capsuleradar", false);
-            p.putInt("rot", g_rotation);
+            p.putInt("rotDeg", g_rotation);
             p.end();
         }
     }
@@ -824,7 +819,10 @@ void setup() {
         g_hideGround = p.getBool("hideground", false);
         g_minAltFt = p.getInt("minalt", 0);
         g_milOnly = p.getBool("milonly", false);
-        g_rotation = p.getInt("rot", 0);
+        // Migrate the old quarter-turn setting (rot=0..3) without changing existing
+        // installations' orientation. New firmware stores actual degrees separately.
+        g_rotation = p.isKey("rotDeg") ? p.getInt("rotDeg", 0) : p.getInt("rot", 0) * 90;
+        g_rotation = constrain(g_rotation, 0, 359);
         p.end();
         radar::setTheme(t);
         radar::setSweepEnabled(g_showSweep);
@@ -834,7 +832,8 @@ void setup() {
         g_adsb.setMilitaryOnly(g_milOnly);
         radar::setTrailLength(g_trailLen);
         radar::setMaxOnScreen(g_maxAc);
-        display::setRotation((uint8_t)g_rotation);
+        display::setRotation((uint16_t)g_rotation);
+        g_rotation = display::rotation();
     }
     radar::setThemeChangedCb(saveTheme);
     ui_set_range_cb(onRangeChange);              // on-screen zoom button


### PR DESCRIPTION
## Summary

This pull request extends the display rotation setting from four fixed orientations
(0°, 90°, 180°, and 270°) to arbitrary clockwise rotation in one-degree increments
from 0° to 359°.

The change is intended for enclosures and mounting arrangements where the display
cannot be aligned precisely to a cardinal orientation.

## Changes

- Replaces the four-option rotation dropdown with a numeric 0–359° control.
- Adds arbitrary-angle framebuffer rotation around the center of the display.
- Applies the inverse rotation to touch coordinates so taps and horizontal swipe
  navigation remain aligned with the visible UI.
- Retains the optimized rendering paths for 0°, 90°, 180°, and 270°.
- Uses fixed-point coordinate calculations in the per-pixel rendering path.
- Batches rotated scanlines to reduce QSPI transactions.
- Clears uncovered display regions when the rotation changes.
- Rejects touches in clipped black corners outside the rotated logical UI.
- Adds safe fallback behavior if the required PSRAM buffers cannot be allocated.
- Persists the selected angle using a new `rotDeg` NVS setting.
- Migrates the previous `rot=0..3` quarter-turn setting to degrees, preserving the
  orientation of existing installations.

## Implementation notes

Arbitrary-angle rotation uses a full 466 × 466 logical framebuffer in PSRAM and
inverse nearest-neighbour sampling of the affected display region. This avoids the
holes and overdraw artifacts that would occur when forward-mapping individual pixels.

The full logical framebuffer requires approximately 424 KiB of additional PSRAM.
Cardinal rotations continue to use the existing optimized paths, although the logical
framebuffer remains allocated so the device can switch to an arbitrary angle at
runtime.

At non-cardinal angles, the corners of the logical square may extend beyond the
physical display and are therefore clipped. Pixels outside the rotated UI are rendered
black.

## Compatibility

Existing saved rotation values remain compatible:

- `rot=0` becomes 0°
- `rot=1` becomes 90°
- `rot=2` becomes 180°
- `rot=3` becomes 270°

New settings are stored separately as `rotDeg`, avoiding ambiguity with the legacy
quarter-turn representation.

## Validation

The ESP32-S3 firmware builds successfully with:

```bash
pio run -e esp32-s3-amoled-175
Build result:
RAM usage: 124,292 bytes (37.9%)
Flash usage: approximately 2.88 MB (44.0%)
The existing cardinal rotation paths are preserved. Additional on-device testing is
recommended for arbitrary-angle rendering performance and touch/swipe behavior across
a representative set of angles.
Files changed
src/display.cpp
src/display.h
src/main.cpp