### PR TITLE
feat(weather): add forecast, precipitation radar, and satellite clouds

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,4 +1,4 @@
-# Features — Plane Radar 2.0
+# Features — Capsule Radar
 
 Visual target: `assets/plane_radar_2.0_mockup.html`.
 
@@ -14,13 +14,27 @@ Visual target: `assets/plane_radar_2.0_mockup.html`.
 
 ## Functions (the "more")
 1. **Touch to inspect** — tap nearest glyph → detail card: callsign, type, registration (if available), altitude, ground speed, vertical-rate arrow, distance, bearing, squawk.
-2. **Views** (swipe): Radar · List (sorted by distance) · Detail · Stats (count, closest, max alt, msgs).
-3. **Range zoom** — cycle 5 / 10 / 25 / 100 km (tap or long-press), re-query radius accordingly.
+2. **Views** (swipe): Radar · List (sorted by distance) · Stats (count, closest, max altitude and range) · Weather. Tap an aircraft to open its detail card.
+3. **Range zoom** — cycle 10 / 20 / 30 / 50 / 100 km and re-query the aircraft feed accordingly.
 4. **Orientation** — north-up ↔ track-up toggle.
 5. **Alerts** — highlight + speaker **ping** for: emergency squawks (7500/7600/7700), military (`dbFlags`), or a user watch-list of types (A380, B52…). Card flashes red (see RESCUE51 in the mockup).
 6. **Night auto-dim** — use PCF85063 RTC to lower brightness after dusk.
 7. **IMU gestures** (QMI8658) — face-down → screen sleep; face-up → wake; shake → force refresh.
 8. **Setup & maintenance** — first-boot **captive portal** (WiFi creds + home lat/lon + range); settings in NVS; **OTA** updates.
+9. **Three-day weather forecast** — a round-display layout with current temperature and condition, apparent temperature, humidity and wind, followed by three aligned daily columns for condition, high/low temperature and rain probability. Data comes from [Open-Meteo](https://open-meteo.com/), uses the saved or GPS-derived radar centre, follows the selected unit preset and refreshes every 30 minutes.
+10. **WX precipitation radar** — a north-up, nearly fullscreen circular precipitation view centred on the saved/GPS position. Aviation-style range rings, centre marker, nearest-IATA context, current-weather footer and source timestamp are rendered as overlays. The approximately 75 km-radius image is cached in PSRAM and refreshed every five minutes from [RainViewer](https://www.rainviewer.com/api.html) (personal/educational use; availability is not guaranteed). This layer shows rain, snow and hail echoes—not ordinary cloud cover.
+11. **Meteosat cloud imagery** — a location-centred, approximately 400 km-wide satellite view from the official [EUMETSAT EUMETView WMS](https://user.eumetsat.int/data-access/eumetview). The Cloud Type RGB product makes cloud structure and classification visible beneath the same aviation overlays, with a separate satellite timestamp and EUMETSAT attribution. Images require no API key, are decoded directly into PSRAM and refresh every ten minutes. Cloud colours describe satellite-derived cloud properties; they do not directly indicate precipitation severity.
+12. **Weather-mode control** — the on-screen control cycles **WX Radar → Sat Clouds → 3-Day Forecast**. The imagery itself can also be tapped to advance to the next mode.
+13. **Graceful network handling** — weather products load independently after WiFi connects, retain their last valid image during transient failures and retry failed requests without blocking the display. Status text distinguishes forecast, precipitation-radar and satellite-data waits.
+14. **Desktop simulator** — the same 466×466 LVGL interface runs locally through SDL2. It includes mock aircraft, forecast data, precipitation cells and Meteosat-style cloud bands, allowing all three weather modes and round-screen layouts to be reviewed without flashing hardware. Live network imagery is fetched only by the ESP32 firmware.
+
+## Weather data at a glance
+
+| Mode | What it shows | Coverage | Provider | Refresh |
+|---|---|---:|---|---:|
+| WX Radar | Measured precipitation echoes | ~75 km radius | RainViewer | 5 min |
+| Sat Clouds | Satellite-derived cloud types | ~400 km across | EUMETSAT | 10 min |
+| 3-Day Forecast | Current conditions and daily outlook | Configured/GPS point | Open-Meteo | 30 min |
 
 ## Nice-to-have / later
 - Route enrichment (origin→destination) via a secondary lookup.

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,6 +47,7 @@ lib_deps =
     lewisxhe/XPowersLib                               ; AXP2101 battery gauge
     bodmer/TJpg_Decoder                               ; JPEG decode for aircraft photos
     mikalhart/TinyGPSPlus                             ; NMEA parsing for the LC76G GPS (-G variant)
+    bitbank2/PNGdec                                   ; decode RainViewer radar tiles into RGB565
 ; Notes:
 ; - lv_conf.h lives in include/ (added to the include path above).
 ; - Versions are pinned to a known-good combination for this panel; bump deliberately.
@@ -62,7 +63,7 @@ upload_port = capsuleradar.local
 [env:native]
 platform = native
 ; Only the portable UI + the SDL sim main; no Arduino_GFX / WiFi / device code.
-build_src_filter = -<*> +<radar_view.cpp> +<ui.cpp> +<route.cpp> +<photo.cpp> +<coastline.cpp> +<airports.cpp> +<sim_main.cpp>
+build_src_filter = -<*> +<radar_view.cpp> +<ui.cpp> +<route.cpp> +<photo.cpp> +<weather.cpp> +<wx_radar.cpp> +<cloud_image.cpp> +<coastline.cpp> +<airports.cpp> +<sim_main.cpp>
 build_flags =
     !sdl2-config --cflags --libs      ; SDL2 include/lib flags (Homebrew sdl2)
     -DLV_CONF_INCLUDE_SIMPLE

--- a/platformio.ini
+++ b/platformio.ini
@@ -34,6 +34,7 @@ build_flags =
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DCORE_DEBUG_LEVEL=0              ; silence Arduino library [E] spam (Wire I2C -1/263, ssl_client);
                                       ;   our own Serial.printf [adsb]/[gps]/[wifi] logs are unaffected
+    -DPNG_MAX_BUFFERED_PIXELS=4098    ; two 512px RGBA scanlines: (512*4+1)*2; PNGdec default only fits 320px
     -DLV_CONF_INCLUDE_SIMPLE          ; LVGL does #include "lv_conf.h"
     -I${PROJECT_DIR}/include          ; ...and finds it here (PIO's auto include/ is not on the LIBRARY path)
     -std=gnu++17

--- a/src/adsb_client.cpp
+++ b/src/adsb_client.cpp
@@ -59,7 +59,16 @@ bool AdsbClient::fetchFrom(const char* host, std::vector<Aircraft>& out) {
     http.addHeader("Accept", "application/json");
 
     const int code = http.GET();
-    if (code != 200) { Serial.printf("[adsb] HTTP %d (%s)\n", code, host); http.end(); return false; }
+    if (code != 200) {
+        char tls[128] = "";
+        const int tlsCode = client.lastError(tls, sizeof(tls));
+        Serial.printf("[adsb] HTTP %d (%s) tls=%d '%s' heap=%u largest=%u psram=%u\n",
+                      code, host, tlsCode, tls,
+                      (unsigned)ESP.getFreeHeap(),
+                      (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+                      (unsigned)ESP.getFreePsram());
+        http.end(); return false;
+    }
 
     // Only keep the fields we use -> much smaller parsed document.
     JsonDocument filter(&s_jsonPsram);

--- a/src/airports.cpp
+++ b/src/airports.cpp
@@ -68,3 +68,26 @@ void airports_draw(lv_draw_ctx_t *ctx, lv_color_t color, lv_opa_t opa) {
         }
     }
 }
+
+bool airports_nearest_iata(double lat, double lon, float maxKm,
+                           char iata[4], float *distKm, float *bearingDeg) {
+    if (iata) iata[0] = 0;
+    double best = maxKm;
+    int bestIdx = -1;
+    for (int i = 0; i < AIRPORT_NUM; ++i) {
+        if (!AIRPORT_IATA[i][0]) continue;
+        const double alat = AIRPORT_LAT[i] / (double)AIRPORT_SCALE;
+        const double alon = AIRPORT_LON[i] / (double)AIRPORT_SCALE;
+        const double d = geo::haversineKm(lat, lon, alat, alon);
+        if (d < best) { best = d; bestIdx = i; }
+    }
+    if (bestIdx < 0) return false;
+    if (iata) memcpy(iata, AIRPORT_IATA[bestIdx], 4);
+    if (distKm) *distKm = (float)best;
+    if (bearingDeg) {
+        const double alat = AIRPORT_LAT[bestIdx] / (double)AIRPORT_SCALE;
+        const double alon = AIRPORT_LON[bestIdx] / (double)AIRPORT_SCALE;
+        *bearingDeg = (float)geo::bearingDeg(lat, lon, alat, alon);
+    }
+    return true;
+}

--- a/src/airports.h
+++ b/src/airports.h
@@ -10,3 +10,8 @@ void airports_project(double homeLat, double homeLon, double rangeKm,
                       float cx, float cy, float rOuterPx);
 
 void airports_draw(lv_draw_ctx_t *ctx, lv_color_t color, lv_opa_t opa);
+
+// Find the nearest recognizable airport (one with an IATA code). Used by the
+// weather view for aviation context; entirely offline from the embedded data.
+bool airports_nearest_iata(double lat, double lon, float maxKm,
+                           char iata[4], float *distKm, float *bearingDeg);

--- a/src/cloud_image.cpp
+++ b/src/cloud_image.cpp
@@ -1,0 +1,51 @@
+#include "cloud_image.h"
+#include <mutex>
+#include <stdlib.h>
+#include <string.h>
+#ifdef ARDUINO
+#include <esp_heap_caps.h>
+#endif
+
+static std::mutex s_mutex;
+static uint16_t *s_front = nullptr, *s_back = nullptr;
+static uint32_t s_frameTime = 0, s_version = 0;
+static double s_lat = 0, s_lon = 0;
+
+static uint16_t *alloc_pixels(void) {
+    const size_t bytes = WX_RADAR_SIZE * WX_RADAR_SIZE * sizeof(uint16_t);
+#ifdef ARDUINO
+    return (uint16_t *)heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    return (uint16_t *)malloc(bytes);
+#endif
+}
+
+void cloud_image_begin(void) {
+    if (s_front) return;
+    s_front = alloc_pixels();
+    s_back = alloc_pixels();
+    const size_t bytes = WX_RADAR_SIZE * WX_RADAR_SIZE * sizeof(uint16_t);
+    if (s_front) memset(s_front, 0, bytes);
+    if (s_back) memset(s_back, 0, bytes);
+}
+
+uint16_t *cloud_image_back_buffer(void) { return s_back; }
+
+void cloud_image_commit(uint32_t frameTime, double lat, double lon) {
+    if (!s_front || !s_back) return;
+    std::lock_guard<std::mutex> lock(s_mutex);
+    uint16_t *old = s_front; s_front = s_back; s_back = old;
+    s_frameTime = frameTime; s_lat = lat; s_lon = lon; ++s_version;
+}
+
+bool cloud_image_front(const uint16_t **pixels, uint32_t *frameTime,
+                       double *lat, double *lon, uint32_t *version) {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    if (!s_front || s_version == 0) return false;
+    if (pixels) *pixels = s_front;
+    if (frameTime) *frameTime = s_frameTime;
+    if (lat) *lat = s_lat;
+    if (lon) *lon = s_lon;
+    if (version) *version = s_version;
+    return true;
+}

--- a/src/cloud_image.h
+++ b/src/cloud_image.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stdint.h>
+#include "wx_radar.h"
+
+void cloud_image_begin(void);
+uint16_t *cloud_image_back_buffer(void);
+void cloud_image_commit(uint32_t frameTime, double lat, double lon);
+bool cloud_image_front(const uint16_t **pixels, uint32_t *frameTime,
+                       double *lat, double *lon, uint32_t *version);

--- a/src/cloud_image_client.cpp
+++ b/src/cloud_image_client.cpp
@@ -1,0 +1,96 @@
+#include "cloud_image_client.h"
+#include "cloud_image.h"
+#include "config.h"
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <TJpg_Decoder.h>
+#include <esp_heap_caps.h>
+#include <time.h>
+
+static uint16_t *s_dst = nullptr;
+
+static bool cloud_jpg_out(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t *bmp) {
+    if (!s_dst) return false;
+    const int c = WX_RADAR_SIZE / 2;
+    for (int j = 0; j < h; ++j) {
+        const int yy = y + j;
+        if (yy < 0 || yy >= WX_RADAR_SIZE) continue;
+        const int dy = yy - c;
+        for (int i = 0; i < w; ++i) {
+            const int xx = x + i;
+            if (xx < 0 || xx >= WX_RADAR_SIZE) continue;
+            const int dx = xx - c;
+            s_dst[yy * WX_RADAR_SIZE + xx] =
+                (dx * dx + dy * dy <= (c - 2) * (c - 2)) ? bmp[j * w + i] : 0;
+        }
+    }
+    return true;
+}
+
+static bool get_jpeg(const char *url, uint8_t **out, size_t *outLen) {
+    *out = nullptr; *outLen = 0;
+    WiFiClientSecure client;
+    client.setInsecure();
+    HTTPClient http;
+    http.setReuse(false);
+    http.setConnectTimeout(4500);
+    http.setTimeout(12000);
+    if (!http.begin(client, url)) return false;
+    http.setUserAgent(ADSB_USER_AGENT);
+    const int status = http.GET();
+    if (status != 200) {
+        char tls[96] = "";
+        const int tlsCode = client.lastError(tls, sizeof(tls));
+        Serial.printf("[clouds] HTTP %d tls=%d '%s'\n", status, tlsCode, tls);
+        http.end(); return false;
+    }
+    String body = http.getString();
+    http.end();
+    if (body.length() < 100 || body.length() > 180000) return false;
+    uint8_t *buf = (uint8_t *)heap_caps_malloc(body.length(), MALLOC_CAP_SPIRAM);
+    if (!buf) return false;
+    memcpy(buf, body.c_str(), body.length());
+    *out = buf; *outLen = body.length();
+    return true;
+}
+
+bool cloud_image_fetch(double lat, double lon) {
+    if (WiFi.status() != WL_CONNECTED || !cloud_image_back_buffer()) return false;
+    // A roughly 440 x 440 km aviation-context window around the configured position.
+    const double latSpan = 2.0;
+    const double lonSpan = 3.0;
+    char url[720];
+    snprintf(url, sizeof(url),
+        "https://view.eumetsat.int/geoserver/wms?service=WMS&version=1.1.1&request=GetMap"
+        "&layers=mtg_fd%%3Argb_cloudtype%%2Cbackgrounds%%3Ane_10m_coastline%%2Cbackgrounds%%3Ane_boundary_lines_land"
+        "&srs=EPSG%%3A4326&bbox=%.5f%%2C%.5f%%2C%.5f%%2C%.5f&width=360&height=360"
+        "&styles=&format=image%%2Fjpeg&bgcolor=0x000000",
+        lon - lonSpan, lat - latSpan, lon + lonSpan, lat + latSpan);
+
+    uint8_t *image = nullptr; size_t imageLen = 0;
+    if (!get_jpeg(url, &image, &imageLen)) {
+        Serial.println("[clouds] image fetch failed"); return false;
+    }
+    uint16_t jw = 0, jh = 0;
+    if (TJpgDec.getJpgSize(&jw, &jh, image, imageLen) != JDR_OK ||
+        jw != WX_RADAR_SIZE || jh != WX_RADAR_SIZE) {
+        Serial.printf("[clouds] unexpected JPEG %ux%u\n", jw, jh);
+        heap_caps_free(image); return false;
+    }
+    s_dst = cloud_image_back_buffer();
+    TJpgDec.setJpgScale(1);
+    TJpgDec.setSwapBytes(false);
+    TJpgDec.setCallback(cloud_jpg_out);
+    const JRESULT result = TJpgDec.drawJpg(0, 0, image, imageLen);
+    heap_caps_free(image);
+    s_dst = nullptr;
+    if (result != JDR_OK) {
+        Serial.printf("[clouds] JPEG decode error %d\n", result); return false;
+    }
+    const uint32_t frameTime = (uint32_t)time(nullptr);
+    cloud_image_commit(frameTime, lat, lon);
+    Serial.printf("[clouds] satellite image updated (%u bytes)\n", (unsigned)imageLen);
+    return true;
+}

--- a/src/cloud_image_client.h
+++ b/src/cloud_image_client.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool cloud_image_fetch(double lat, double lon);

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,11 @@ static const float RANGE_STEPS_KM[] = {10.0f, 20.0f, 30.0f, 50.0f, 100.0f};
 #define MOTION_INTERP       1              // 1 = glyphs glide between polls; 0 = snap to new pos
 #define AC_STALE_MS         15000          // drop aircraft not refreshed in this long
 
+// ---------- Weather forecast (Open-Meteo, no API key) ----------
+#define WEATHER_REFRESH_MS  1800000UL      // 30 minutes; forecast data changes slowly
+#define WX_RADAR_REFRESH_MS 300000UL       // RainViewer frames update about every 5 minutes
+#define CLOUD_IMAGE_REFRESH_MS 600000UL    // EUMETSAT MTG cloud imagery; cache for 10 minutes
+
 // ---------- Screen (CO5300 AMOLED) ----------
 #define SCREEN_W            466
 #define SCREEN_H            466

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,12 @@
 #include "route_client.h"
 #include "photo.h"
 #include "photo_client.h"
+#include "weather.h"
+#include "weather_client.h"
+#include "wx_radar.h"
+#include "wx_radar_client.h"
+#include "cloud_image.h"
+#include "cloud_image_client.h"
 #include "radar_view.h"
 #include "ui.h"
 #include "display.h"                  // M0: CO5300 + LVGL bring-up
@@ -64,6 +70,9 @@ static volatile bool         g_feedOk = true;                        // ADS-B fe
 static volatile uint32_t     g_lastFeedOkMs = 0;                     // millis() of the last good poll (HUD staleness)
 static volatile uint32_t     g_rebootAtMs = 0;                       // !=0: reboot when millis() reaches it (clean start after WiFi config)
 static String                g_tz = TZ_STR;                          // POSIX timezone (web-configurable, NVS); applied via configTzTime
+static volatile bool         g_weatherDirty = false;
+static volatile bool         g_wxRadarDirty = false;
+static volatile bool         g_cloudImageDirty = false;
 
 // Web-selectable time zones (label + POSIX TZ). The <option> value is the index; the save
 // handler maps it back to the POSIX string stored in NVS and used by configTzTime at boot.
@@ -96,6 +105,9 @@ static void adsb_task(void*) {
     std::vector<Aircraft> fresh;
     bool wasConnected = false;
     uint32_t lastPoll = 0;
+    uint32_t nextWeatherAt = UINT32_MAX;       // armed five seconds after WiFi connects
+    uint32_t nextWxRadarAt = UINT32_MAX;
+    uint32_t nextCloudImageAt = UINT32_MAX;
     uint32_t lastFeedOk = millis();          // self-heal: time of last good (or no-WiFi) poll
     for (;;) {
         const bool conn = (WiFi.status() == WL_CONNECTED);
@@ -106,6 +118,9 @@ static void adsb_task(void*) {
             Serial.printf("[adsb] WiFi up, IP %s\n", WiFi.localIP().toString().c_str());
             configTzTime(g_tz.c_str(), "pool.ntp.org", "time.nist.gov");  // local time (web-configurable TZ)
             Serial.println("[web] config: http://capsuleradar.local/  (or the IP above)");
+            nextWeatherAt = millis() + 5000UL; // let the first ADS-B poll complete before weather TLS
+            nextCloudImageAt = millis() + 15000UL;
+            nextWxRadarAt = millis() + 12000UL;
             // mDNS + OTA are started on core 1 (loop) to keep all mDNS use on one core
         }
         wasConnected = conn;
@@ -147,6 +162,41 @@ static void adsb_task(void*) {
                 } else {
                     Serial.println("[adsb] poll failed");
                     if (++failCount >= 5) g_feedOk = false;   // sustained outage -> HUD warning
+                }
+            }
+            // Forecasts change slowly. Fetch only after the live ADS-B poll has had priority.
+            if ((int32_t)(nowMs - nextWeatherAt) >= 0) {
+                Serial.printf("[weather] fetching %.5f, %.5f...\n",
+                              g_settings.homeLat, g_settings.homeLon);
+                WeatherSnapshot forecast;
+                if (weather_fetch(g_settings.homeLat, g_settings.homeLon, forecast)) {
+                    weather_store(forecast);
+                    g_weatherDirty = true;
+                    nextWeatherAt = millis() + WEATHER_REFRESH_MS;
+                    Serial.println("[weather] forecast updated");
+                } else {
+                    nextWeatherAt = millis() + 60000UL;
+                    Serial.println("[weather] fetch failed; retrying in 60s");
+                }
+            }
+            if ((int32_t)(nowMs - nextWxRadarAt) >= 0) {
+                Serial.println("[wxradar] fetching latest frame...");
+                if (wx_radar_fetch(g_settings.homeLat, g_settings.homeLon)) {
+                    g_wxRadarDirty = true;
+                    nextWxRadarAt = millis() + WX_RADAR_REFRESH_MS;
+                } else {
+                    nextWxRadarAt = millis() + 60000UL;
+                    Serial.println("[wxradar] fetch failed; retrying in 60s");
+                }
+            }
+            if ((int32_t)(nowMs - nextCloudImageAt) >= 0) {
+                Serial.println("[clouds] fetching EUMETSAT frame...");
+                if (cloud_image_fetch(g_settings.homeLat, g_settings.homeLon)) {
+                    g_cloudImageDirty = true;
+                    nextCloudImageAt = millis() + CLOUD_IMAGE_REFRESH_MS;
+                } else {
+                    nextCloudImageAt = millis() + 60000UL;
+                    Serial.println("[clouds] fetch failed; retrying in 60s");
                 }
             }
             // Then the on-demand lookups for the selected aircraft. Their timeouts are kept
@@ -904,6 +954,8 @@ void setup() {
     // --- ADS-B client + task ----------------------------------------------
     float queryKm = queryRadiusKm();
     g_adsb.begin(g_settings.homeLat, g_settings.homeLon, queryKm);
+    wx_radar_begin();
+    cloud_image_begin();
     g_ac_mutex = xSemaphoreCreateMutex();
     xTaskCreatePinnedToCore(adsb_task, "adsb", 16384, nullptr, 1, nullptr, 0);  // TLS needs a big stack
 
@@ -970,6 +1022,18 @@ void loop() {
             checkAudioEvents();                // ping new-in-range / emergency / military
         }
     }
+    if (g_weatherDirty) {
+        g_weatherDirty = false;
+        ui_on_data_updated();
+    }
+    if (g_wxRadarDirty) {
+        g_wxRadarDirty = false;
+        ui_on_data_updated();
+    }
+    if (g_cloudImageDirty) {
+        g_cloudImageDirty = false;
+        ui_on_data_updated();
+    }
 
     // periodic: HUD clock + wifi/battery indicators
     static uint32_t lastStatus = 0;
@@ -1005,7 +1069,7 @@ void loop() {
         char net[112];
         if (WiFi.status() == WL_CONNECTED)
             // IP + the active centre point (helps users verify what actually got saved)
-            snprintf(net, sizeof(net), "Configure at\ncapsuleradar.local\n%s  \xc2\xb7  %.5f, %.5f",
+            snprintf(net, sizeof(net), "Configure at\ncapsuleradar.local\n%s  |  %.5f, %.5f",
                      WiFi.localIP().toString().c_str(), g_settings.homeLat, g_settings.homeLon);
         else
             snprintf(net, sizeof(net), "WiFi setup:\njoin CapsuleRadar-Setup");

--- a/src/sim_main.cpp
+++ b/src/sim_main.cpp
@@ -16,6 +16,9 @@
 #include "radar_view.h"
 #include "ui.h"
 #include "route.h"
+#include "weather.h"
+#include "wx_radar.h"
+#include "cloud_image.h"
 #include "aircraft.h"
 #include <vector>
 #include <cmath>
@@ -167,6 +170,65 @@ int main(int argc, char **argv) {
     mock_init();
     radar::update(g_mockAcs, g_set);
     ui_on_data_updated();
+    WeatherSnapshot forecast = {};
+    forecast.valid = true;
+    snprintf(forecast.updated, sizeof(forecast.updated), "14:00");
+    forecast.code = 1; forecast.tempC = 27; forecast.feelsC = 29;
+    forecast.humidity = 61; forecast.windKmh = 18; forecast.windDeg = 85;
+    const char *dates[] = {"2026-06-08", "2026-06-09", "2026-06-10", "2026-06-11"};
+    const int codes[] = {1, 2, 61, 0};
+    const float lows[] = {20, 19, 18, 21}, highs[] = {28, 27, 24, 29};
+    const int rain[] = {10, 20, 75, 5};
+    forecast.dayCount = 4;
+    for (int i = 0; i < 4; ++i) {
+        snprintf(forecast.days[i].date, sizeof(forecast.days[i].date), "%s", dates[i]);
+        forecast.days[i].code = codes[i]; forecast.days[i].tempMinC = lows[i];
+        forecast.days[i].tempMaxC = highs[i]; forecast.days[i].rainChance = rain[i];
+    }
+    weather_store(forecast);
+    wx_radar_begin();
+    if (uint16_t *wx = wx_radar_back_buffer()) {
+        for (int y = 0; y < WX_RADAR_SIZE; ++y) for (int x = 0; x < WX_RADAR_SIZE; ++x) {
+            const int centre = WX_RADAR_SIZE / 2;
+            const int dx = x - centre, dy = y - centre;
+            uint16_t c = 0;
+            if (dx * dx + dy * dy < (centre - 2) * (centre - 2)) {
+                const int a = (x - 250) * (x - 250) + (y - 115) * (y - 115);
+                const int b = (x - 105) * (x - 105) + (y - 245) * (y - 245);
+                if (a < 1500) c = a < 350 ? 0xFBE0 : (a < 800 ? 0xFFE0 : 0x07E0);
+                if (b < 900) c = b < 250 ? 0xF800 : 0x07E0;
+            }
+            wx[y * WX_RADAR_SIZE + x] = c;
+        }
+        wx_radar_commit(1784397600UL, HOME_LAT_DEFAULT, HOME_LON_DEFAULT);
+    }
+    // Representative Meteosat-style mock. The native simulator has no network
+    // clients, so populate the shared satellite buffer with a dark Earth field
+    // and layered cloud bands that exercise the exact same UI path as hardware.
+    cloud_image_begin();
+    if (uint16_t *sat = cloud_image_back_buffer()) {
+        const int centre = WX_RADAR_SIZE / 2;
+        for (int y = 0; y < WX_RADAR_SIZE; ++y) for (int x = 0; x < WX_RADAR_SIZE; ++x) {
+            const int dx = x - centre, dy = y - centre;
+            uint16_t c = 0;
+            if (dx * dx + dy * dy < (centre - 2) * (centre - 2)) {
+                const float wave1 = y - (116.0f + 0.42f * x + 20.0f * sinf(x * 0.035f));
+                const float wave2 = y - (320.0f - 0.52f * x + 14.0f * sinf(x * 0.055f));
+                const float cloud = expf(-(wave1 * wave1) / 950.0f) +
+                                    0.75f * expf(-(wave2 * wave2) / 620.0f);
+                const float texture = 0.72f + 0.28f * sinf(x * 0.19f + y * 0.11f) *
+                                                       sinf(x * 0.047f - y * 0.16f);
+                const float v = fminf(1.0f, cloud * texture);
+                const int r = (int)(8 + 235 * v);
+                const int g = (int)(23 + 225 * v);
+                const int b = (int)(42 + 205 * v);
+                c = (uint16_t)(((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3));
+            }
+            sat[y * WX_RADAR_SIZE + x] = c;
+        }
+        cloud_image_commit(1784397900UL, HOME_LAT_DEFAULT, HOME_LON_DEFAULT);
+    }
+    ui_on_data_updated();
     printf("[sim] Capsule Radar simulator running (%dx%d) with 6 mock aircraft.\n", SIM_W, SIM_H);
 
     Uint32 last = SDL_GetTicks();
@@ -240,7 +302,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        // headless screenshot mode (--shot <prefix>): settle, then grab all 3 views
+        // headless screenshot mode (--shot <prefix>): settle, then grab all views/themes
         if (shotPath && now - start > 4000) {
             for (int k = 0; k < 150; ++k) {              // fast-forward to build up the flow map
                 mock_step(1.0);
@@ -252,17 +314,20 @@ int main(int argc, char **argv) {
             ui_on_data_updated();                        // pick up the mock route for the card
             int ow, oh;
             SDL_GetRendererOutputSize(s_ren, &ow, &oh);
-            struct Shot { const char *name; int view; int theme; };
-            const Shot shots[6] = {
-                { "radar",  0, THEME_PHOSPHOR },
-                { "orb", 0, THEME_ORB   },
-                { "amber",  0, THEME_AMBER    },
-                { "military",0, THEME_MILITARY },
-                { "list",   1, THEME_PHOSPHOR },
-                { "stats",  2, THEME_PHOSPHOR },
+            struct Shot { const char *name; int view; int theme; bool forecast; };
+            const Shot shots[8] = {
+                { "radar",  0, THEME_PHOSPHOR, false },
+                { "orb", 0, THEME_ORB, false },
+                { "amber",  0, THEME_AMBER, false },
+                { "military",0, THEME_MILITARY, false },
+                { "list",   1, THEME_PHOSPHOR, false },
+                { "stats",  2, THEME_PHOSPHOR, false },
+                { "weather",3, THEME_PHOSPHOR, false },
+                { "forecast",3, THEME_PHOSPHOR, true },
             };
-            for (int v = 0; v < 6; ++v) {
+            for (int v = 0; v < 8; ++v) {
                 radar::setTheme(shots[v].theme);
+                ui_set_weather_forecast(shots[v].forecast);
                 ui_show_view(shots[v].view);
                 lv_refr_now(NULL);                       // force the view into the buffer
                 SDL_RenderClear(s_ren);

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -4,11 +4,16 @@
 #include "radar_view.h"
 #include "route.h"
 #include "photo.h"
+#include "weather.h"
+#include "wx_radar.h"
+#include "cloud_image.h"
+#include "airports.h"
 #include "config.h"
 #include <lvgl.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <time.h>
 
 #define UI_GREEN lv_color_hex(0x1DFF86)
 #define UI_INK   lv_color_hex(0xEAFFF3)
@@ -18,7 +23,7 @@
 #define UI_EMERG lv_color_hex(0xFF5A3C)
 
 static lv_obj_t *s_tv = nullptr;
-static lv_obj_t *s_tileRadar = nullptr, *s_tileList = nullptr, *s_tileStats = nullptr;
+static lv_obj_t *s_tileRadar = nullptr, *s_tileList = nullptr, *s_tileStats = nullptr, *s_tileWeather = nullptr;
 static lv_obj_t *s_card = nullptr, *s_cardTitle = nullptr, *s_cardL = nullptr, *s_cardR = nullptr;
 static lv_obj_t *s_cardRoute = nullptr;
 static lv_obj_t *s_photo = nullptr, *s_photoCredit = nullptr;   // aircraft photo above the card
@@ -30,6 +35,22 @@ static lv_obj_t *s_statsLbl = nullptr;
 static lv_obj_t *s_statsNet = nullptr;
 static lv_obj_t *s_hudGps   = nullptr;   // HUD satellite icon (hidden unless GPS auto-location is on)
 static lv_obj_t *s_statsGps = nullptr;   // Stats view GPS status line
+static lv_obj_t *s_weatherNow = nullptr, *s_weatherMeta = nullptr, *s_weatherDays = nullptr;
+static lv_obj_t *s_wxCanvas = nullptr, *s_wxStatus = nullptr, *s_wxAirport = nullptr;
+static lv_obj_t *s_wxFooter = nullptr, *s_wxMeta = nullptr, *s_wxAttrib = nullptr;
+static lv_obj_t *s_wxRings[3] = { nullptr, nullptr, nullptr };
+static lv_obj_t *s_wxNorth = nullptr, *s_wxCenter = nullptr, *s_wxRange = nullptr;
+static lv_obj_t *s_weatherModeBtn = nullptr, *s_weatherModeLbl = nullptr;
+static lv_obj_t *s_weatherTitle = nullptr;
+enum WeatherViewMode { WEATHER_RADAR, WEATHER_CLOUDS, WEATHER_FORECAST };
+static WeatherViewMode s_weatherMode = WEATHER_RADAR;
+static lv_obj_t *s_fcCurrent = nullptr, *s_fcCondition = nullptr, *s_fcUpdated = nullptr;
+static lv_obj_t *s_fcMetricName[3] = { nullptr, nullptr, nullptr };
+static lv_obj_t *s_fcMetricValue[3] = { nullptr, nullptr, nullptr };
+static lv_obj_t *s_fcDay[3] = { nullptr, nullptr, nullptr };
+static lv_obj_t *s_fcDayCondition[3] = { nullptr, nullptr, nullptr };
+static lv_obj_t *s_fcDayTemp[3] = { nullptr, nullptr, nullptr };
+static lv_obj_t *s_fcDayRain[3] = { nullptr, nullptr, nullptr };
 
 // --------------------------------------------------------------------- units
 // 0 = Aviation (ft, kt, km) · 1 = Metric (m, km/h, km) · 2 = Imperial (ft, mph, mi).
@@ -59,6 +80,20 @@ static float dist_val(float km) {
     return km;                                   // Metric   -> km
 }
 static const char *dist_unit(void) { return s_units == 0 ? "nm" : (s_units == 2 ? "mi" : "km"); }
+
+static float weather_temp(float c) { return s_units == 2 ? c * 1.8f + 32.0f : c; }
+static const char *weather_temp_unit(void) { return s_units == 2 ? "F" : "C"; }
+static float weather_wind(float kmh) {
+    if (s_units == 0) return kmh * 0.539957f;
+    if (s_units == 2) return kmh * 0.621371f;
+    return kmh;
+}
+static const char *weather_wind_unit(void) { return s_units == 0 ? "kt" : (s_units == 2 ? "mph" : "km/h"); }
+static const char *cardinal(float deg) {
+    static const char *p[] = {"N", "NE", "E", "SE", "S", "SW", "W", "NW"};
+    int i = ((int)(deg + 22.5f) / 45) & 7;
+    return p[i];
+}
 
 // Fold Latin-1 accents / drop any other non-ASCII so the Montserrat font never hits a
 // missing glyph (which renders as an empty box). Belt-and-suspenders for card text.
@@ -349,12 +384,159 @@ static void build_stats(void) {
     lv_label_set_text(s_statsLbl, st);
 }
 
+static void build_weather(void) {
+    if (!s_weatherNow || !s_weatherMeta || !s_weatherDays || !s_wxFooter) return;
+    WeatherSnapshot w;
+    if (!weather_get(w)) {
+        lv_label_set_text(s_weatherNow, "Forecast unavailable");
+        lv_label_set_text(s_weatherMeta, "Waiting for WiFi data...");
+        lv_label_set_text(s_wxFooter, "WEATHER DATA PENDING");
+        lv_label_set_text(s_weatherDays, "");
+    } else {
+        char now[96];
+        snprintf(now, sizeof(now), "%.0f %s\n%s", weather_temp(w.tempC),
+                 weather_temp_unit(), weather_condition(w.code));
+        lv_label_set_text(s_weatherNow, now);
+        char meta[128];
+        snprintf(meta, sizeof(meta), "Feels %.0f %s   Humidity %d%%\nWind %.0f %s  %s   Updated %s",
+                 weather_temp(w.feelsC), weather_temp_unit(), w.humidity,
+                 weather_wind(w.windKmh), weather_wind_unit(), cardinal((float)w.windDeg), w.updated);
+        lv_label_set_text(s_weatherMeta, meta);
+
+        char footer[96];
+        snprintf(footer, sizeof(footer), "%.0f %s   %s", weather_temp(w.tempC),
+                 weather_temp_unit(), weather_condition(w.code));
+        lv_label_set_text(s_wxFooter, footer);
+        char wxmeta[96];
+        snprintf(wxmeta, sizeof(wxmeta), "WIND %s %.0f %s   HUM %d%%",
+                 cardinal((float)w.windDeg), weather_wind(w.windKmh), weather_wind_unit(), w.humidity);
+        lv_label_set_text(s_wxMeta, wxmeta);
+
+        char current[24];
+        snprintf(current, sizeof(current), "%.0f %s", weather_temp(w.tempC), weather_temp_unit());
+        lv_label_set_text(s_fcCurrent, current);
+        lv_label_set_text(s_fcCondition, weather_condition(w.code));
+        lv_label_set_text(s_fcMetricValue[0], current);
+        char hum[16]; snprintf(hum, sizeof(hum), "%d%%", w.humidity);
+        lv_label_set_text(s_fcMetricValue[1], hum);
+        char wind[28]; snprintf(wind, sizeof(wind), "%s %.0f %s", cardinal((float)w.windDeg),
+                                weather_wind(w.windKmh), weather_wind_unit());
+        lv_label_set_text(s_fcMetricValue[2], wind);
+        char updated[24]; snprintf(updated, sizeof(updated), "UPDATED %s", w.updated);
+        lv_label_set_text(s_fcUpdated, updated);
+
+        for (int col = 0; col < 3; ++col) {
+            const int i = col + 1;
+            if (i < w.dayCount) {
+                lv_label_set_text(s_fcDay[col], weather_day_name(w.days[i].date));
+                lv_label_set_text(s_fcDayCondition[col], weather_condition(w.days[i].code));
+                char temps[28];
+                snprintf(temps, sizeof(temps), "%.0f / %.0f %s",
+                         weather_temp(w.days[i].tempMaxC), weather_temp(w.days[i].tempMinC), weather_temp_unit());
+                lv_label_set_text(s_fcDayTemp[col], temps);
+                char chance[20]; snprintf(chance, sizeof(chance), "RAIN %d%%", w.days[i].rainChance);
+                lv_label_set_text(s_fcDayRain[col], chance);
+            } else {
+                lv_label_set_text(s_fcDay[col], "-");
+                lv_label_set_text(s_fcDayCondition[col], "");
+                lv_label_set_text(s_fcDayTemp[col], "");
+                lv_label_set_text(s_fcDayRain[col], "");
+            }
+        }
+
+        char days[320] = "";
+        for (int i = 1; i < w.dayCount && i < 4; ++i) {
+            char row[104];
+            snprintf(row, sizeof(row), "%-3s  %-14s  %2.0f/%2.0f %s  %3d%%\n",
+                     weather_day_name(w.days[i].date), weather_condition(w.days[i].code),
+                     weather_temp(w.days[i].tempMaxC), weather_temp(w.days[i].tempMinC),
+                     weather_temp_unit(), w.days[i].rainChance);
+            strncat(days, row, sizeof(days) - strlen(days) - 1);
+        }
+        lv_label_set_text(s_weatherDays, days);
+    }
+
+    const uint16_t *radarPixels = nullptr, *cloudPixels = nullptr;
+    uint32_t frameTime = 0, version = 0;
+    double rlat = 0, rlon = 0;
+    const bool cloudMode = s_weatherMode == WEATHER_CLOUDS;
+    const bool forecastMode = s_weatherMode == WEATHER_FORECAST;
+    bool haveImage = false;
+    if (cloudMode)
+        haveImage = cloud_image_front(&cloudPixels, &frameTime, &rlat, &rlon, &version);
+    else
+        haveImage = wx_radar_front(&radarPixels, &frameTime, &rlat, &rlon, &version);
+    const uint16_t *pixels = cloudMode ? cloudPixels : radarPixels;
+    if (haveImage && pixels && s_wxCanvas) {
+        lv_canvas_set_buffer(s_wxCanvas, (void *)pixels, WX_RADAR_SIZE, WX_RADAR_SIZE, LV_IMG_CF_TRUE_COLOR);
+        lv_obj_clear_flag(s_wxCanvas, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(s_wxStatus, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_invalidate(s_wxCanvas);
+        char iata[4]; float d = 0, b = 0;
+        if (airports_nearest_iata(rlat, rlon, 200.0f, iata, &d, &b)) {
+            char apt[64];
+            snprintf(apt, sizeof(apt), "O  %s   %.0f %s %s", iata, dist_val(d), dist_unit(), cardinal(b));
+            lv_label_set_text(s_wxAirport, apt);
+        } else lv_label_set_text(s_wxAirport, "RADAR CENTRE");
+        char stamp[6] = "--:--";
+        time_t ft = (time_t)frameTime; struct tm ti;
+        if (frameTime && localtime_r(&ft, &ti)) snprintf(stamp, sizeof(stamp), "%02d:%02d", ti.tm_hour, ti.tm_min);
+        char attr[64];
+        snprintf(attr, sizeof(attr), cloudMode ? "SAT %s  |  EUMETSAT" : "RADAR %s  |  RAINVIEWER", stamp);
+        lv_label_set_text(s_wxAttrib, attr);
+    } else {
+        if (s_wxCanvas) lv_obj_add_flag(s_wxCanvas, LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(s_wxStatus, LV_OBJ_FLAG_HIDDEN);
+        lv_label_set_text(s_wxAirport, "RADAR CENTRE");
+        lv_label_set_text(s_wxAttrib, cloudMode ? "WAITING FOR SATELLITE DATA" : "WAITING FOR RADAR DATA");
+    }
+
+    lv_obj_t *forecastObjs[] = {
+        s_fcCurrent, s_fcCondition, s_fcUpdated,
+        s_fcMetricName[0], s_fcMetricName[1], s_fcMetricName[2],
+        s_fcMetricValue[0], s_fcMetricValue[1], s_fcMetricValue[2],
+        s_fcDay[0], s_fcDay[1], s_fcDay[2],
+        s_fcDayCondition[0], s_fcDayCondition[1], s_fcDayCondition[2],
+        s_fcDayTemp[0], s_fcDayTemp[1], s_fcDayTemp[2],
+        s_fcDayRain[0], s_fcDayRain[1], s_fcDayRain[2]
+    };
+    lv_obj_t *radarObjs[] = { s_wxCanvas, s_wxStatus, s_wxAirport, s_wxFooter, s_wxMeta,
+                              s_wxAttrib, s_wxNorth, s_wxCenter, s_wxRange,
+                              s_wxRings[0], s_wxRings[1], s_wxRings[2] };
+    for (lv_obj_t *o : forecastObjs) if (o) {
+        if (forecastMode) lv_obj_clear_flag(o, LV_OBJ_FLAG_HIDDEN); else lv_obj_add_flag(o, LV_OBJ_FLAG_HIDDEN);
+    }
+    for (lv_obj_t *o : radarObjs) if (o) {
+        if (forecastMode) lv_obj_add_flag(o, LV_OBJ_FLAG_HIDDEN); else lv_obj_clear_flag(o, LV_OBJ_FLAG_HIDDEN);
+    }
+    if (!forecastMode && haveImage) lv_obj_add_flag(s_wxStatus, LV_OBJ_FLAG_HIDDEN);
+    if (!forecastMode && !haveImage) lv_obj_add_flag(s_wxCanvas, LV_OBJ_FLAG_HIDDEN);
+    lv_label_set_text(s_wxRange, cloudMode ? "200 KM" : "75 KM");
+    lv_label_set_text(s_weatherModeLbl,
+        s_weatherMode == WEATHER_RADAR ? "CLOUDS" :
+        s_weatherMode == WEATHER_CLOUDS ? "3-DAY FORECAST" : "WX RADAR");
+    if (s_weatherTitle) lv_label_set_text(s_weatherTitle,
+        s_weatherMode == WEATHER_RADAR ? "WX RADAR" :
+        s_weatherMode == WEATHER_CLOUDS ? "SAT CLOUDS" : "WEATHER");
+}
+
+static void weather_mode_cb(lv_event_t *) {
+    s_weatherMode = (WeatherViewMode)(((int)s_weatherMode + 1) % 3);
+    build_weather();
+}
+
+void ui_set_weather_forecast(bool forecast) {
+    s_weatherMode = forecast ? WEATHER_FORECAST : WEATHER_RADAR;
+    build_weather();
+}
+
 // Rebuild whichever of list/stats is currently on screen (called on poll and on swipe).
 static void refresh_active_tile(void) {
     if (!s_tv) return;
     lv_obj_t *act = lv_tileview_get_tile_act(s_tv);
     if (act == s_tileList)  build_list();
     else if (act == s_tileStats) build_stats();
+    else if (act == s_tileWeather) build_weather();
 }
 
 void ui_on_data_updated(void) {
@@ -447,7 +629,7 @@ static void build_card(void) {
 }
 
 void ui_show_view(int idx) {
-    if (s_tv && idx >= 0 && idx <= 2) lv_obj_set_tile_id(s_tv, (uint32_t)idx, 0, LV_ANIM_OFF);
+    if (s_tv && idx >= 0 && idx <= 3) lv_obj_set_tile_id(s_tv, (uint32_t)idx, 0, LV_ANIM_OFF);
 }
 
 // ------------------------------------------------------------------- splash
@@ -527,7 +709,8 @@ void ui_create(void) {
 
     s_tileRadar = lv_tileview_add_tile(s_tv, 0, 0, LV_DIR_RIGHT);
     s_tileList  = lv_tileview_add_tile(s_tv, 1, 0, LV_DIR_HOR);
-    s_tileStats = lv_tileview_add_tile(s_tv, 2, 0, LV_DIR_LEFT);
+    s_tileStats = lv_tileview_add_tile(s_tv, 2, 0, LV_DIR_HOR);
+    s_tileWeather = lv_tileview_add_tile(s_tv, 3, 0, LV_DIR_LEFT);
     // Rebuild the list/stats with the latest data the moment they slide into view
     // (between polls they'd otherwise show whatever was there when last visible).
     lv_obj_add_event_cb(s_tv, [](lv_event_t *) { refresh_active_tile(); }, LV_EVENT_VALUE_CHANGED, nullptr);
@@ -650,6 +833,203 @@ void ui_create(void) {
     lv_obj_set_style_text_color(ver, UI_DIM, 0);
     lv_label_set_text(ver, "Capsule Radar v" FW_VERSION);
     lv_obj_align(ver, LV_ALIGN_CENTER, 0, 170);
+
+    // --- weather tile (current conditions + next three days) ---
+    lv_obj_t *wp = make_round_panel(s_tileWeather);
+    lv_obj_set_style_bg_color(wp, lv_color_black(), 0); // hide square radar-tile bounds on AMOLED
+    s_weatherTitle = make_tile_title(wp, "WX RADAR");
+    lv_obj_set_style_bg_color(s_weatherTitle, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(s_weatherTitle, 170, 0);
+    lv_obj_set_style_pad_left(s_weatherTitle, 8, 0);
+    lv_obj_set_style_pad_right(s_weatherTitle, 8, 0);
+    lv_obj_set_style_pad_top(s_weatherTitle, 2, 0);
+    lv_obj_set_style_pad_bottom(s_weatherTitle, 2, 0);
+    lv_obj_set_style_radius(s_weatherTitle, 8, 0);
+    s_weatherNow = lv_label_create(wp);
+    lv_obj_set_width(s_weatherNow, 330);
+    lv_obj_set_style_text_font(s_weatherNow, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(s_weatherNow, UI_INK, 0);
+    lv_obj_set_style_text_align(s_weatherNow, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text(s_weatherNow, "Forecast unavailable");
+    lv_obj_align(s_weatherNow, LV_ALIGN_TOP_MID, 0, 64);
+
+    s_weatherMeta = lv_label_create(wp);
+    lv_obj_set_width(s_weatherMeta, 380);
+    lv_obj_set_style_text_font(s_weatherMeta, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(s_weatherMeta, UI_SOFT, 0);
+    lv_obj_set_style_text_align(s_weatherMeta, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text(s_weatherMeta, "Waiting for WiFi data...");
+    lv_obj_align(s_weatherMeta, LV_ALIGN_TOP_MID, 0, 150);
+
+    s_weatherDays = lv_label_create(wp);
+    lv_obj_set_width(s_weatherDays, 390);
+    lv_obj_set_style_text_font(s_weatherDays, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(s_weatherDays, UI_GREEN, 0);
+    lv_obj_set_style_text_align(s_weatherDays, LV_TEXT_ALIGN_LEFT, 0);
+    lv_label_set_text(s_weatherDays, "");
+    lv_obj_align(s_weatherDays, LV_ALIGN_TOP_LEFT, 42, 234);
+    // Legacy formatted labels are retained only to avoid touching older data-update
+    // plumbing; the redesigned forecast uses independent aligned objects below.
+    lv_obj_add_flag(s_weatherNow, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(s_weatherMeta, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(s_weatherDays, LV_OBJ_FLAG_HIDDEN);
+
+    // Default mode: genuine precipitation radar with aviation-style overlays.
+    s_wxAirport = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_wxAirport, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(s_wxAirport, UI_SOFT, 0);
+    lv_obj_set_style_bg_color(s_wxAirport, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(s_wxAirport, 160, 0);
+    lv_obj_set_style_pad_left(s_wxAirport, 6, 0);
+    lv_obj_set_style_pad_right(s_wxAirport, 6, 0);
+    lv_obj_set_style_radius(s_wxAirport, 6, 0);
+    lv_label_set_text(s_wxAirport, "RADAR CENTRE");
+    lv_obj_align(s_wxAirport, LV_ALIGN_TOP_MID, 0, 46);
+
+    s_wxCanvas = lv_canvas_create(wp);
+    lv_obj_set_size(s_wxCanvas, WX_RADAR_SIZE, WX_RADAR_SIZE);
+    lv_obj_align(s_wxCanvas, LV_ALIGN_TOP_MID, 0, 52);
+    lv_obj_add_flag(s_wxCanvas, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_event_cb(s_wxCanvas, weather_mode_cb, LV_EVENT_CLICKED, nullptr);
+    lv_obj_add_flag(s_wxCanvas, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_background(s_wxCanvas);
+
+    s_wxStatus = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_wxStatus, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(s_wxStatus, UI_DIM, 0);
+    lv_label_set_text(s_wxStatus, "ACQUIRING WX RADAR...");
+    lv_obj_align(s_wxStatus, LV_ALIGN_TOP_MID, 0, 222);
+
+    const int ringSize[3] = { 360, 240, 120 };
+    for (int i = 0; i < 3; ++i) {
+        s_wxRings[i] = lv_obj_create(wp);
+        lv_obj_remove_style_all(s_wxRings[i]);
+        lv_obj_set_size(s_wxRings[i], ringSize[i], ringSize[i]);
+        lv_obj_align(s_wxRings[i], LV_ALIGN_TOP_MID, 0, 52 + (360 - ringSize[i]) / 2);
+        lv_obj_set_style_radius(s_wxRings[i], LV_RADIUS_CIRCLE, 0);
+        lv_obj_set_style_border_color(s_wxRings[i], UI_GREEN, 0);
+        lv_obj_set_style_border_opa(s_wxRings[i], i == 0 ? 180 : 90, 0);
+        lv_obj_set_style_border_width(s_wxRings[i], 1, 0);
+        lv_obj_clear_flag(s_wxRings[i], LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
+    }
+    s_wxNorth = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_wxNorth, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(s_wxNorth, UI_GREEN, 0);
+    lv_label_set_text(s_wxNorth, "N");
+    lv_obj_align(s_wxNorth, LV_ALIGN_TOP_MID, 0, 58);
+    s_wxCenter = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_wxCenter, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(s_wxCenter, UI_INK, 0);
+    lv_label_set_text(s_wxCenter, "+");
+    lv_obj_align(s_wxCenter, LV_ALIGN_TOP_MID, 0, 219);
+    s_wxRange = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_wxRange, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(s_wxRange, UI_GREEN, 0);
+    lv_label_set_text(s_wxRange, "75 KM");
+    lv_obj_align(s_wxRange, LV_ALIGN_TOP_MID, 128, 225);
+
+    s_wxFooter = lv_label_create(wp);
+    lv_obj_set_width(s_wxFooter, 360);
+    lv_obj_set_style_text_font(s_wxFooter, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(s_wxFooter, UI_INK, 0);
+    lv_obj_set_style_text_align(s_wxFooter, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text(s_wxFooter, "WEATHER DATA PENDING");
+    lv_obj_align(s_wxFooter, LV_ALIGN_TOP_MID, 0, 326);
+    lv_obj_set_style_bg_color(s_wxFooter, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(s_wxFooter, 185, 0);
+    lv_obj_set_style_pad_hor(s_wxFooter, 8, 0);
+    lv_obj_set_style_radius(s_wxFooter, 7, 0);
+    s_wxMeta = lv_label_create(wp);
+    lv_obj_set_width(s_wxMeta, 360);
+    lv_obj_set_style_text_font(s_wxMeta, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(s_wxMeta, UI_SOFT, 0);
+    lv_obj_set_style_text_align(s_wxMeta, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text(s_wxMeta, "");
+    lv_obj_align(s_wxMeta, LV_ALIGN_TOP_MID, 0, 351);
+    lv_obj_set_style_bg_color(s_wxMeta, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(s_wxMeta, 185, 0);
+    lv_obj_set_style_pad_hor(s_wxMeta, 8, 0);
+    lv_obj_set_style_radius(s_wxMeta, 7, 0);
+    s_wxAttrib = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_wxAttrib, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(s_wxAttrib, UI_DIM, 0);
+    lv_label_set_text(s_wxAttrib, "WAITING FOR RADAR DATA");
+    lv_obj_align(s_wxAttrib, LV_ALIGN_TOP_MID, 0, 376);
+    lv_obj_set_style_bg_color(s_wxAttrib, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(s_wxAttrib, 170, 0);
+    lv_obj_set_style_pad_hor(s_wxAttrib, 6, 0);
+    lv_obj_set_style_radius(s_wxAttrib, 6, 0);
+
+    // Forecast mode: independent, aligned objects instead of a tiny text table.
+    s_fcCurrent = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_fcCurrent, &lv_font_montserrat_28, 0);
+    lv_obj_set_style_text_color(s_fcCurrent, UI_INK, 0);
+    lv_label_set_text(s_fcCurrent, "-- C");
+    lv_obj_align(s_fcCurrent, LV_ALIGN_TOP_MID, 0, 68);
+    s_fcCondition = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_fcCondition, &lv_font_montserrat_16, 0);
+    lv_obj_set_style_text_color(s_fcCondition, UI_SOFT, 0);
+    lv_label_set_text(s_fcCondition, "Waiting for data");
+    lv_obj_align(s_fcCondition, LV_ALIGN_TOP_MID, 0, 105);
+
+    const char *metricNames[3] = { "FEELS", "HUMIDITY", "WIND" };
+    const int colX[3] = { -122, 0, 122 };
+    for (int i = 0; i < 3; ++i) {
+        s_fcMetricName[i] = lv_label_create(wp);
+        lv_obj_set_style_text_font(s_fcMetricName[i], &lv_font_montserrat_12, 0);
+        lv_obj_set_style_text_color(s_fcMetricName[i], UI_DIM, 0);
+        lv_label_set_text(s_fcMetricName[i], metricNames[i]);
+        lv_obj_align(s_fcMetricName[i], LV_ALIGN_TOP_MID, colX[i], 150);
+        s_fcMetricValue[i] = lv_label_create(wp);
+        lv_obj_set_style_text_font(s_fcMetricValue[i], &lv_font_montserrat_16, 0);
+        lv_obj_set_style_text_color(s_fcMetricValue[i], UI_INK, 0);
+        lv_label_set_text(s_fcMetricValue[i], "-");
+        lv_obj_align(s_fcMetricValue[i], LV_ALIGN_TOP_MID, colX[i], 170);
+
+        s_fcDay[i] = lv_label_create(wp);
+        lv_obj_set_style_text_font(s_fcDay[i], &lv_font_montserrat_16, 0);
+        lv_obj_set_style_text_color(s_fcDay[i], UI_GREEN, 0);
+        lv_label_set_text(s_fcDay[i], "---");
+        lv_obj_align(s_fcDay[i], LV_ALIGN_TOP_MID, colX[i], 226);
+        s_fcDayCondition[i] = lv_label_create(wp);
+        lv_obj_set_width(s_fcDayCondition[i], 116);
+        lv_obj_set_style_text_font(s_fcDayCondition[i], &lv_font_montserrat_12, 0);
+        lv_obj_set_style_text_color(s_fcDayCondition[i], UI_SOFT, 0);
+        lv_obj_set_style_text_align(s_fcDayCondition[i], LV_TEXT_ALIGN_CENTER, 0);
+        lv_label_set_long_mode(s_fcDayCondition[i], LV_LABEL_LONG_WRAP);
+        lv_label_set_text(s_fcDayCondition[i], "");
+        lv_obj_align(s_fcDayCondition[i], LV_ALIGN_TOP_MID, colX[i], 254);
+        s_fcDayTemp[i] = lv_label_create(wp);
+        lv_obj_set_style_text_font(s_fcDayTemp[i], &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(s_fcDayTemp[i], UI_INK, 0);
+        lv_label_set_text(s_fcDayTemp[i], "");
+        lv_obj_align(s_fcDayTemp[i], LV_ALIGN_TOP_MID, colX[i], 292);
+        s_fcDayRain[i] = lv_label_create(wp);
+        lv_obj_set_style_text_font(s_fcDayRain[i], &lv_font_montserrat_12, 0);
+        lv_obj_set_style_text_color(s_fcDayRain[i], lv_color_hex(0x4DDCFF), 0);
+        lv_label_set_text(s_fcDayRain[i], "");
+        lv_obj_align(s_fcDayRain[i], LV_ALIGN_TOP_MID, colX[i], 320);
+    }
+    s_fcUpdated = lv_label_create(wp);
+    lv_obj_set_style_text_font(s_fcUpdated, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(s_fcUpdated, UI_DIM, 0);
+    lv_label_set_text(s_fcUpdated, "");
+    lv_obj_align(s_fcUpdated, LV_ALIGN_TOP_MID, 0, 365);
+
+    s_weatherModeBtn = lv_btn_create(wp);
+    lv_obj_set_size(s_weatherModeBtn, 164, 34);
+    lv_obj_align(s_weatherModeBtn, LV_ALIGN_BOTTOM_MID, 0, -18);
+    lv_obj_set_style_radius(s_weatherModeBtn, 17, 0);
+    lv_obj_set_style_bg_color(s_weatherModeBtn, UI_PANEL, 0);
+    lv_obj_set_style_border_color(s_weatherModeBtn, UI_GREEN, 0);
+    lv_obj_set_style_border_width(s_weatherModeBtn, 1, 0);
+    lv_obj_clear_flag(s_weatherModeBtn, LV_OBJ_FLAG_SCROLL_CHAIN);
+    lv_obj_add_event_cb(s_weatherModeBtn, weather_mode_cb, LV_EVENT_CLICKED, nullptr);
+    s_weatherModeLbl = lv_label_create(s_weatherModeBtn);
+    lv_obj_set_style_text_font(s_weatherModeLbl, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(s_weatherModeLbl, UI_GREEN, 0);
+    lv_label_set_text(s_weatherModeLbl, "3-DAY FORECAST");
+    lv_obj_center(s_weatherModeLbl);
 
     lv_obj_set_tile_id(s_tv, 0, 0, LV_ANIM_OFF);
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -3,7 +3,7 @@
 // Pure LVGL, portable (device + SDL simulator). Builds on top of radar_view.
 void ui_create(void);            // build the whole UI on the active screen
 void ui_on_data_updated(void);   // refresh card/list/stats after radar::update()
-void ui_show_view(int idx);      // 0 = radar, 1 = list, 2 = stats
+void ui_show_view(int idx);      // 0 = radar, 1 = list, 2 = stats, 3 = weather
 void ui_set_status(bool wifiUp, bool feedOk, int rssi, const char *clock);  // HUD: signal bars (count=RSSI, colour: red=down, amber=stale feed, white=ok) + clock
 void ui_set_battery(int pct, bool charging, bool present);  // top HUD battery indicator
 void ui_set_date(const char *date);  // top HUD date line (e.g. "08 Jun 2026")
@@ -13,3 +13,4 @@ void ui_splash_show(void);  // branded boot splash (auto-fades, covers init time
 void ui_set_range_cb(void (*cb)(float km));  // on-screen zoom button -> notify main
 void ui_set_range_km(float km);              // update the zoom button label / sync the cycle
 void ui_set_units(int preset);               // 0 = Aviation (ft,kt,km) · 1 = Metric (m,km/h,km) · 2 = Imperial (ft,mph,mi)
+void ui_set_weather_forecast(bool forecast); // false = WX radar, true = 3-day forecast

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -1,0 +1,43 @@
+#include "weather.h"
+#include <mutex>
+#include <string.h>
+#include <stdio.h>
+
+static std::mutex s_mutex;
+static WeatherSnapshot s_snapshot = {};
+
+void weather_store(const WeatherSnapshot &snapshot) {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    s_snapshot = snapshot;
+}
+
+bool weather_get(WeatherSnapshot &snapshot) {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    snapshot = s_snapshot;
+    return snapshot.valid;
+}
+
+const char *weather_condition(int code) {
+    if (code == 0) return "Clear";
+    if (code <= 2) return "Partly cloudy";
+    if (code == 3) return "Overcast";
+    if (code == 45 || code == 48) return "Fog";
+    if (code >= 51 && code <= 57) return "Drizzle";
+    if (code >= 61 && code <= 67) return "Rain";
+    if (code >= 71 && code <= 77) return "Snow";
+    if (code >= 80 && code <= 82) return "Showers";
+    if (code >= 85 && code <= 86) return "Snow showers";
+    if (code >= 95) return "Thunderstorm";
+    return "Unknown";
+}
+
+const char *weather_day_name(const char *isoDate) {
+    static const char *names[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+    if (!isoDate || strlen(isoDate) < 10) return "---";
+    int y = 0, m = 0, d = 0;
+    if (sscanf(isoDate, "%d-%d-%d", &y, &m, &d) != 3) return "---";
+    if (m < 3) { m += 12; --y; }
+    const int k = y % 100, j = y / 100;
+    const int h = (d + (13 * (m + 1)) / 5 + k + k / 4 + j / 4 + 5 * j) % 7;
+    return names[(h + 6) % 7];
+}

--- a/src/weather.h
+++ b/src/weather.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stddef.h>
+
+// Portable weather snapshot shared by the network task and LVGL UI.
+// Temperatures are Celsius, wind is km/h and precipitation is millimetres;
+// the UI converts these according to the selected unit preset.
+struct WeatherDay {
+    char date[11];
+    int code;
+    float tempMinC;
+    float tempMaxC;
+    int rainChance;
+};
+
+struct WeatherSnapshot {
+    bool valid;
+    char updated[6];
+    int code;
+    float tempC;
+    float feelsC;
+    int humidity;
+    float windKmh;
+    int windDeg;
+    WeatherDay days[4];
+    int dayCount;
+};
+
+void weather_store(const WeatherSnapshot &snapshot);
+bool weather_get(WeatherSnapshot &snapshot);
+const char *weather_condition(int code);
+const char *weather_day_name(const char *isoDate);

--- a/src/weather_client.cpp
+++ b/src/weather_client.cpp
@@ -1,0 +1,99 @@
+#include "weather_client.h"
+#include "config.h"
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <ArduinoJson.h>
+#include <esp_heap_caps.h>
+#include <stdio.h>
+#include <string.h>
+
+bool weather_fetch(double lat, double lon, WeatherSnapshot &out) {
+    if (WiFi.status() != WL_CONNECTED) return false;
+
+    char url[512];
+    snprintf(url, sizeof(url),
+             "https://api.open-meteo.com/v1/forecast?latitude=%.5f&longitude=%.5f"
+             "&current=temperature_2m,apparent_temperature,relative_humidity_2m,weather_code,wind_speed_10m,wind_direction_10m"
+             "&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max"
+             "&forecast_days=4&timezone=auto", lat, lon);
+
+    WiFiClientSecure client;
+    client.setInsecure();
+    HTTPClient http;
+    http.setReuse(false);
+    http.setConnectTimeout(3500);
+    http.setTimeout(7000);
+    if (!http.begin(client, url)) {
+        Serial.println("[weather] HTTP begin failed");
+        return false;
+    }
+    http.addHeader("User-Agent", ADSB_USER_AGENT);
+
+    const int status = http.GET();
+    if (status != 200) {
+        char tls[128] = "";
+        const int tlsCode = client.lastError(tls, sizeof(tls));
+        Serial.printf("[weather] HTTP %d: %s tls=%d '%s' heap=%u largest=%u psram=%u\n", status,
+                      status < 0 ? http.errorToString(status).c_str() : "unexpected response",
+                      tlsCode, tls, (unsigned)ESP.getFreeHeap(),
+                      (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+                      (unsigned)ESP.getFreePsram());
+        http.end();
+        return false;
+    }
+
+    // Open-Meteo replies with Transfer-Encoding: chunked. HTTPClient::getString()
+    // removes the chunk framing; parsing getStream() directly makes ArduinoJson
+    // see the hexadecimal chunk size first and report InvalidInput.
+    String payload = http.getString();
+    http.end();
+    if (payload.length() == 0) {
+        Serial.println("[weather] empty response body");
+        return false;
+    }
+
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, payload);
+    if (err) {
+        Serial.printf("[weather] JSON error: %s (%u bytes, starts '%.24s')\n",
+                      err.c_str(), (unsigned)payload.length(), payload.c_str());
+        return false;
+    }
+
+    WeatherSnapshot next = {};
+    JsonObjectConst current = doc["current"].as<JsonObjectConst>();
+    JsonObjectConst daily = doc["daily"].as<JsonObjectConst>();
+    if (current.isNull() || daily.isNull()) {
+        Serial.println("[weather] response missing current/daily data");
+        return false;
+    }
+
+    const char *stamp = current["time"] | "";
+    const char *clock = strchr(stamp, 'T');
+    snprintf(next.updated, sizeof(next.updated), "%.5s", clock ? clock + 1 : "--:--");
+    next.code = current["weather_code"] | -1;
+    next.tempC = current["temperature_2m"] | 0.0f;
+    next.feelsC = current["apparent_temperature"] | next.tempC;
+    next.humidity = current["relative_humidity_2m"] | 0;
+    next.windKmh = current["wind_speed_10m"] | 0.0f;
+    next.windDeg = current["wind_direction_10m"] | 0;
+
+    JsonArrayConst dates = daily["time"].as<JsonArrayConst>();
+    JsonArrayConst codes = daily["weather_code"].as<JsonArrayConst>();
+    JsonArrayConst highs = daily["temperature_2m_max"].as<JsonArrayConst>();
+    JsonArrayConst lows = daily["temperature_2m_min"].as<JsonArrayConst>();
+    JsonArrayConst rain = daily["precipitation_probability_max"].as<JsonArrayConst>();
+    const size_t count = dates.size() < 4 ? dates.size() : 4;
+    for (size_t i = 0; i < count; ++i) {
+        snprintf(next.days[i].date, sizeof(next.days[i].date), "%s", dates[i] | "");
+        next.days[i].code = codes[i] | -1;
+        next.days[i].tempMaxC = highs[i] | 0.0f;
+        next.days[i].tempMinC = lows[i] | 0.0f;
+        next.days[i].rainChance = rain[i] | 0;
+    }
+    next.dayCount = (int)count;
+    next.valid = true;
+    out = next;
+    return true;
+}

--- a/src/weather_client.h
+++ b/src/weather_client.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "weather.h"
+
+// Fetch current conditions and a four-day forecast from Open-Meteo.
+bool weather_fetch(double lat, double lon, WeatherSnapshot &out);

--- a/src/wx_radar.cpp
+++ b/src/wx_radar.cpp
@@ -1,0 +1,51 @@
+#include "wx_radar.h"
+#include <mutex>
+#include <stdlib.h>
+#include <string.h>
+#ifdef ARDUINO
+#include <esp_heap_caps.h>
+#endif
+
+static std::mutex s_mutex;
+static uint16_t *s_front = nullptr, *s_back = nullptr;
+static uint32_t s_frameTime = 0, s_version = 0;
+static double s_lat = 0, s_lon = 0;
+
+static uint16_t *alloc_pixels(void) {
+    const size_t bytes = WX_RADAR_SIZE * WX_RADAR_SIZE * sizeof(uint16_t);
+#ifdef ARDUINO
+    return (uint16_t *)heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+#else
+    return (uint16_t *)malloc(bytes);
+#endif
+}
+
+void wx_radar_begin(void) {
+    if (s_front) return;
+    s_front = alloc_pixels();
+    s_back = alloc_pixels();
+    const size_t bytes = WX_RADAR_SIZE * WX_RADAR_SIZE * sizeof(uint16_t);
+    if (s_front) memset(s_front, 0, bytes);
+    if (s_back) memset(s_back, 0, bytes);
+}
+
+uint16_t *wx_radar_back_buffer(void) { return s_back; }
+
+void wx_radar_commit(uint32_t frameTime, double lat, double lon) {
+    if (!s_front || !s_back) return;
+    std::lock_guard<std::mutex> lock(s_mutex);
+    uint16_t *old = s_front; s_front = s_back; s_back = old;
+    s_frameTime = frameTime; s_lat = lat; s_lon = lon; ++s_version;
+}
+
+bool wx_radar_front(const uint16_t **pixels, uint32_t *frameTime,
+                    double *lat, double *lon, uint32_t *version) {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    if (!s_front || s_version == 0) return false;
+    if (pixels) *pixels = s_front;
+    if (frameTime) *frameTime = s_frameTime;
+    if (lat) *lat = s_lat;
+    if (lon) *lon = s_lon;
+    if (version) *version = s_version;
+    return true;
+}

--- a/src/wx_radar.h
+++ b/src/wx_radar.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <stdint.h>
+
+#define WX_RADAR_SIZE 360
+#define WX_RADAR_SOURCE_SIZE 512
+
+void wx_radar_begin(void);
+uint16_t *wx_radar_back_buffer(void);                    // network/sim: decode here
+void wx_radar_commit(uint32_t frameTime, double lat, double lon);
+bool wx_radar_front(const uint16_t **pixels, uint32_t *frameTime,
+                    double *lat, double *lon, uint32_t *version);

--- a/src/wx_radar_client.cpp
+++ b/src/wx_radar_client.cpp
@@ -1,0 +1,97 @@
+#include "wx_radar_client.h"
+#include "wx_radar.h"
+#include "config.h"
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <ArduinoJson.h>
+#include <PNGdec.h>
+#include <esp_heap_caps.h>
+#include <new>
+
+// PNG contains a ~46 KB inflate workspace. A global PNG object places that in
+// scarce internal BSS and starves TLS of a contiguous allocation, breaking every
+// HTTPS client. Construct the decoder itself in PSRAM instead.
+static PNG *s_png = nullptr;
+
+static bool ensure_decoder(void) {
+    if (s_png) return true;
+    void *mem = heap_caps_malloc(sizeof(PNG), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!mem) { Serial.println("[wxradar] PSRAM decoder allocation failed"); return false; }
+    s_png = new (mem) PNG();
+    Serial.printf("[wxradar] PNG decoder in PSRAM (%u bytes)\n", (unsigned)sizeof(PNG));
+    return true;
+}
+
+static int radar_png_line(PNGDRAW *draw) {
+    uint16_t *dst = wx_radar_back_buffer();
+    const int crop = (WX_RADAR_SOURCE_SIZE - WX_RADAR_SIZE) / 2;
+    if (!dst || draw->y < crop || draw->y >= crop + WX_RADAR_SIZE) return 1;
+    uint16_t line[WX_RADAR_SOURCE_SIZE];
+    s_png->getLineAsRGB565(draw, line, PNG_RGB565_LITTLE_ENDIAN, 0x00000000);
+    const int outY = draw->y - crop;
+    const int c = WX_RADAR_SIZE / 2;
+    const int dy = outY - c;
+    for (int outX = 0; outX < WX_RADAR_SIZE; ++outX) {
+        const int dx = outX - c;
+        dst[outY * WX_RADAR_SIZE + outX] =
+            (dx * dx + dy * dy <= (c - 2) * (c - 2)) ? line[outX + crop] : 0;
+    }
+    return 1;
+}
+
+static bool https_get_string(const char *url, String &body, int timeoutMs) {
+    WiFiClientSecure client;
+    client.setInsecure();
+    HTTPClient http;
+    http.setReuse(false);
+    http.setConnectTimeout(3500);
+    http.setTimeout(timeoutMs);
+    if (!http.begin(client, url)) return false;
+    http.addHeader("User-Agent", ADSB_USER_AGENT);
+    const int status = http.GET();
+    if (status != 200) {
+        char tls[128] = "";
+        const int tlsCode = client.lastError(tls, sizeof(tls));
+        Serial.printf("[wxradar] HTTP %d tls=%d '%s' heap=%u largest=%u psram=%u\n",
+                      status, tlsCode, tls, (unsigned)ESP.getFreeHeap(),
+                      (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
+                      (unsigned)ESP.getFreePsram());
+        http.end(); return false;
+    }
+    body = http.getString();
+    http.end();
+    return body.length() > 0;
+}
+
+bool wx_radar_fetch(double lat, double lon) {
+    if (WiFi.status() != WL_CONNECTED || !wx_radar_back_buffer() || !ensure_decoder()) return false;
+
+    String meta;
+    if (!https_get_string("https://api.rainviewer.com/public/weather-maps.json", meta, 6500)) {
+        Serial.println("[wxradar] metadata fetch failed"); return false;
+    }
+    JsonDocument doc;
+    if (deserializeJson(doc, meta)) { Serial.println("[wxradar] metadata JSON failed"); return false; }
+    const char *host = doc["host"] | "";
+    JsonArrayConst past = doc["radar"]["past"].as<JsonArrayConst>();
+    if (!host[0] || past.size() == 0) { Serial.println("[wxradar] no radar frames"); return false; }
+    JsonObjectConst latest = past[past.size() - 1].as<JsonObjectConst>();
+    const char *path = latest["path"] | "";
+    const uint32_t frameTime = latest["time"] | 0;
+
+    char url[320];
+    snprintf(url, sizeof(url), "%s%s/512/7/%.5f/%.5f/2/1_1.png",
+             host, path, lat, lon);
+    String image;
+    if (!https_get_string(url, image, 8500)) { Serial.println("[wxradar] tile fetch failed"); return false; }
+    const int opened = s_png->openRAM((uint8_t *)image.c_str(), image.length(), radar_png_line);
+    if (opened != PNG_SUCCESS) { Serial.printf("[wxradar] PNG open error %d\n", opened); return false; }
+    const int decoded = s_png->decode(nullptr, 0);
+    s_png->close();
+    if (decoded != PNG_SUCCESS) { Serial.printf("[wxradar] PNG decode error %d\n", decoded); return false; }
+    wx_radar_commit(frameTime, lat, lon);
+    Serial.printf("[wxradar] frame %lu updated (%u bytes)\n",
+                  (unsigned long)frameTime, (unsigned)image.length());
+    return true;
+}

--- a/src/wx_radar_client.cpp
+++ b/src/wx_radar_client.cpp
@@ -9,10 +9,11 @@
 #include <esp_heap_caps.h>
 #include <new>
 
-// PNG contains a ~46 KB inflate workspace. A global PNG object places that in
-// scarce internal BSS and starves TLS of a contiguous allocation, breaking every
-// HTTPS client. Construct the decoder itself in PSRAM instead.
 static PNG *s_png = nullptr;
+static uint32_t s_decodedPixels = 0;
+static uint32_t s_sourcePixels = 0;
+static int s_minX = WX_RADAR_SOURCE_SIZE, s_minY = WX_RADAR_SOURCE_SIZE;
+static int s_maxX = -1, s_maxY = -1;
 
 static bool ensure_decoder(void) {
     if (s_png) return true;
@@ -26,16 +27,34 @@ static bool ensure_decoder(void) {
 static int radar_png_line(PNGDRAW *draw) {
     uint16_t *dst = wx_radar_back_buffer();
     const int crop = (WX_RADAR_SOURCE_SIZE - WX_RADAR_SIZE) / 2;
-    if (!dst || draw->y < crop || draw->y >= crop + WX_RADAR_SIZE) return 1;
+    if (!dst) return 1;
     uint16_t line[WX_RADAR_SOURCE_SIZE];
-    s_png->getLineAsRGB565(draw, line, PNG_RGB565_LITTLE_ENDIAN, 0x00000000);
+    if (draw->iPixelType == PNG_PIXEL_TRUECOLOR_ALPHA && draw->iBpp == 8) {
+        const uint8_t *src = draw->pPixels;
+        for (int x = 0; x < draw->iWidth; ++x, src += 4) {
+            line[x] = (uint16_t)((src[2] >> 3) | ((src[1] >> 2) << 5) |
+                                 ((src[0] >> 3) << 11));
+        }
+    } else {
+        s_png->getLineAsRGB565(draw, line, PNG_RGB565_LITTLE_ENDIAN, 0x00000000);
+    }
+    for (int x = 0; x < draw->iWidth; ++x) if (line[x]) {
+        ++s_sourcePixels;
+        if (x < s_minX) s_minX = x;
+        if (x > s_maxX) s_maxX = x;
+        if (draw->y < s_minY) s_minY = draw->y;
+        if (draw->y > s_maxY) s_maxY = draw->y;
+    }
+    if (draw->y < crop || draw->y >= crop + WX_RADAR_SIZE) return 1;
     const int outY = draw->y - crop;
     const int c = WX_RADAR_SIZE / 2;
     const int dy = outY - c;
     for (int outX = 0; outX < WX_RADAR_SIZE; ++outX) {
         const int dx = outX - c;
-        dst[outY * WX_RADAR_SIZE + outX] =
+        const uint16_t pixel =
             (dx * dx + dy * dy <= (c - 2) * (c - 2)) ? line[outX + crop] : 0;
+        dst[outY * WX_RADAR_SIZE + outX] = pixel;
+        if (pixel) ++s_decodedPixels;
     }
     return 1;
 }
@@ -85,13 +104,30 @@ bool wx_radar_fetch(double lat, double lon) {
              host, path, lat, lon);
     String image;
     if (!https_get_string(url, image, 8500)) { Serial.println("[wxradar] tile fetch failed"); return false; }
+    memset(wx_radar_back_buffer(), 0, WX_RADAR_SIZE * WX_RADAR_SIZE * sizeof(uint16_t));
+    s_decodedPixels = 0;
+    s_sourcePixels = 0;
+    s_minX = s_minY = WX_RADAR_SOURCE_SIZE;
+    s_maxX = s_maxY = -1;
     const int opened = s_png->openRAM((uint8_t *)image.c_str(), image.length(), radar_png_line);
     if (opened != PNG_SUCCESS) { Serial.printf("[wxradar] PNG open error %d\n", opened); return false; }
+    Serial.printf("[wxradar] PNG %dx%d bpp=%d type=%d alpha=%d\n",
+                  s_png->getWidth(), s_png->getHeight(), s_png->getBpp(),
+                  s_png->getPixelType(), s_png->hasAlpha());
+    if (s_png->getWidth() != WX_RADAR_SOURCE_SIZE || s_png->getHeight() != WX_RADAR_SOURCE_SIZE) {
+        Serial.println("[wxradar] unexpected tile dimensions");
+        s_png->close(); return false;
+    }
     const int decoded = s_png->decode(nullptr, 0);
     s_png->close();
     if (decoded != PNG_SUCCESS) { Serial.printf("[wxradar] PNG decode error %d\n", decoded); return false; }
+    if (s_decodedPixels == 0) {
+        Serial.println("[wxradar] decoded tile is empty (0 coloured pixels)");
+    }
     wx_radar_commit(frameTime, lat, lon);
-    Serial.printf("[wxradar] frame %lu updated (%u bytes)\n",
-                  (unsigned long)frameTime, (unsigned)image.length());
+    Serial.printf("[wxradar] frame %lu updated (%u bytes, source=%lu bbox=%d,%d-%d,%d crop=%lu)\n",
+                  (unsigned long)frameTime, (unsigned)image.length(),
+                  (unsigned long)s_sourcePixels, s_minX, s_minY, s_maxX, s_maxY,
+                  (unsigned long)s_decodedPixels);
     return true;
 }

--- a/src/wx_radar_client.h
+++ b/src/wx_radar_client.h
@@ -1,0 +1,3 @@
+#pragma once
+
+bool wx_radar_fetch(double lat, double lon);


### PR DESCRIPTION
Added 3 additional Weather information panels for right swipe. 
WX RainViewer Radar
Sat Cloud Radar
Weather forecast
from the GPS or defined location. No API Keys needed and no account setup needed for external web services. 

Added Photos from my spare development board.

- add Open-Meteo current conditions and three-day forecast
- add fullscreen RainViewer precipitation radar
- add EUMETSAT Meteosat cloud imagery
- centre weather layers on the saved or GPS location
- show nearest-airport context and aviation overlays

<img width="3024" height="4032" alt="IMG_3298" src="https://github.com/user-attachments/assets/02a8650f-f04d-402b-b315-9f0ed4dbdd05" />
<img width="3024" height="4032" alt="IMG_3297" src="https://github.com/user-attachments/assets/3d141548-9f01-4fe6-9b7a-833f19ae0280" />
<img width="3024" height="4032" alt="IMG_3296" src="https://github.com/user-attachments/assets/e747f065-4632-4f96-864f-65422c65827f" />