### PR TITLE
Add ESP32-S3-Touch-AMOLED-1.43 as a second supported board

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,15 +30,26 @@ jobs:
       # other boards carry a suffix (e.g. CapsuleRadar-esp32s3-amoled143.bin).
       - name: Build and merge every board
         run: |
-          BOOT_APP0="$(find "$HOME/.platformio/packages" -name boot_app0.bin -path '*framework-arduinoespressif32*' | head -1)"
+          set -euo pipefail
           build() {   # build <pio-env> <filename-suffix>
             local env="$1" sfx="$2" b=".pio/build/$1"
             pio run -e "$env"
+            # Look for boot_app0.bin AFTER the build, not before: on a clean runner
+            # ~/.platformio/packages does not exist until the first `pio run` installs the
+            # toolchain, so hoisting this above the builds silently yields an empty path and
+            # esptool then fails with "No such file or directory: ''".
+            local boot_app0
+            boot_app0="$(find "$HOME/.platformio/packages" -name boot_app0.bin -path '*framework-arduinoespressif32*' 2>/dev/null | head -1)"
+            if [ -z "$boot_app0" ]; then
+              echo "::error::boot_app0.bin not found under $HOME/.platformio/packages after building $env"
+              find "$HOME/.platformio/packages" -name '*.bin' 2>/dev/null | head -20
+              return 1
+            fi
             python -m esptool --chip esp32s3 merge_bin -o "CapsuleRadar-esp32s3$sfx.bin" \
               --flash_mode dio --flash_freq 80m --flash_size 16MB \
               0x0     "$b/bootloader.bin" \
               0x8000  "$b/partitions.bin" \
-              0xe000  "$BOOT_APP0" \
+              0xe000  "$boot_app0" \
               0x10000 "$b/firmware.bin"
             cp "$b/firmware.bin" "CapsuleRadar-ota$sfx.bin"   # app-only image for the web OTA page
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,20 +25,25 @@ jobs:
       - name: Install PlatformIO + esptool
         run: pip install platformio esptool
 
-      - name: Build firmware
-        run: pio run -e esp32-s3-amoled-175
-
-      - name: Merge into a single flashable binary
+      # Every supported board is built and attached to the same release. The 1.75 keeps
+      # the historic unsuffixed filenames so existing links and instructions still work;
+      # other boards carry a suffix (e.g. CapsuleRadar-esp32s3-amoled143.bin).
+      - name: Build and merge every board
         run: |
-          B=.pio/build/esp32-s3-amoled-175
           BOOT_APP0="$(find "$HOME/.platformio/packages" -name boot_app0.bin -path '*framework-arduinoespressif32*' | head -1)"
-          python -m esptool --chip esp32s3 merge_bin -o CapsuleRadar-esp32s3.bin \
-            --flash_mode dio --flash_freq 80m --flash_size 16MB \
-            0x0     "$B/bootloader.bin" \
-            0x8000  "$B/partitions.bin" \
-            0xe000  "$BOOT_APP0" \
-            0x10000 "$B/firmware.bin"
-          cp "$B/firmware.bin" CapsuleRadar-ota.bin   # app-only image for the device's web OTA page
+          build() {   # build <pio-env> <filename-suffix>
+            local env="$1" sfx="$2" b=".pio/build/$1"
+            pio run -e "$env"
+            python -m esptool --chip esp32s3 merge_bin -o "CapsuleRadar-esp32s3$sfx.bin" \
+              --flash_mode dio --flash_freq 80m --flash_size 16MB \
+              0x0     "$b/bootloader.bin" \
+              0x8000  "$b/partitions.bin" \
+              0xe000  "$BOOT_APP0" \
+              0x10000 "$b/firmware.bin"
+            cp "$b/firmware.bin" "CapsuleRadar-ota$sfx.bin"   # app-only image for the web OTA page
+          }
+          build esp32-s3-amoled-175 ""
+          build esp32-s3-amoled-143 "-amoled143"
 
       - name: Publish release
         uses: softprops/action-gh-release@v2
@@ -46,6 +51,8 @@ jobs:
           files: |
             CapsuleRadar-esp32s3.bin
             CapsuleRadar-ota.bin
+            CapsuleRadar-esp32s3-amoled143.bin
+            CapsuleRadar-ota-amoled143.bin
           generate_release_notes: true
           body: |
             **First flash (USB):** `CapsuleRadar-esp32s3.bin` — the full merged image (offset `0x0`).
@@ -55,3 +62,9 @@ jobs:
             **Update over WiFi (no cable):** `CapsuleRadar-ota.bin` — the app-only image.
             Open `http://capsuleradar.local/update` on the device and upload this file.
             (Do **not** upload the merged image there.)
+
+            **Which file?** Unsuffixed files are for the reference **ESP32-S3-Touch-AMOLED-1.75**.
+            Files with `amoled143` in the name are for the **ESP32-S3-Touch-AMOLED-1.43**.
+            The two boards have completely different pin maps — the wrong image gives a
+            black screen, so check your board before flashing. (The browser flasher
+            currently installs the 1.75 build only.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,16 @@ The visual target is in `assets/plane_radar_2.0_mockup.html` — open it in a br
 - Display: CO5300 AMOLED, 466×466, QSPI. Brightness via panel command (no PWM backlight pin).
 - Touch: CST9217, I2C.
 - IMU: QMI8658 (I2C). RTC: PCF85063 (I2C). PMIC: AXP2101 (I2C 0x34). Audio: ES8311 codec + speaker, dual mic.
-- **Verified pins**: LCD_CS=12, LCD_RST=39, TP_INT=11, TP_RST=40, touch mirror_x/y = true.
-- **Pins still to confirm from the official demo**: QSPI SCLK + D0..D3, and the shared I2C SDA/SCL. Do NOT guess these — copy them from the Waveshare Arduino factory demo (see below). They are left as `-1` placeholders in `src/config.h`.
+- All pins for the reference board are confirmed and live in `src/boards/board_amoled_175.h`.
+
+### Second supported board: ESP32-S3-Touch-AMOLED-1.43
+Same SoC and the same 466x466 CO5300 panel, but a **completely different pin map**, an
+**FT3168** touch controller, and **no PMIC and no audio codec**. Pins are confirmed and live
+in `src/boards/board_amoled_143.h`. Build it with `-e esp32-s3-amoled-143`.
+Gotchas worth remembering: its FT3168 shares the panel reset, so it is absent from I2C until
+the display is initialised, and its QSPI CS/SCLK (GPIO 9/10) are the 1.75's I2S BCLK/DIN —
+which is why audio must stay compiled out here. The panel gap is the same 6 as the 1.75.
+Full detail in `docs/HARDWARE.md`.
 
 ## Stack decision
 **PlatformIO + Arduino framework.** Libraries:
@@ -57,7 +65,8 @@ plane-radar-2.0/
 ├─ README.md
 ├─ platformio.ini
 ├─ src/
-│  ├─ config.h           ← user/build config + pin map (EDIT pins from demo)
+│  ├─ config.h           ← shared tunables; selects a board header
+│  ├─ boards/            ← one header per board (pin map, panel gaps, what's fitted)
 │  ├─ geo.h              ← haversine / bearing / project-to-screen (complete)
 │  ├─ aircraft.h         ← Aircraft data model
 │  ├─ adsb_client.h/.cpp ← fetch + parse airplanes.live (working draft, untested on HW)
@@ -75,11 +84,13 @@ plane-radar-2.0/
 
 ## Build / flash
 ```
-pio run                        # build
-pio run -t upload              # flash over USB-C
-pio device monitor -b 115200   # serial
+pio run -e esp32-s3-amoled-175              # build (reference board)
+pio run -e esp32-s3-amoled-143              # build (1.43)
+pio run -e esp32-s3-amoled-175 -t upload    # flash over USB-C
+pio device monitor -b 115200                # serial
 ```
-First make the Waveshare `01_HelloWorld` equivalent light up, then bring this scaffold's pins in line and build upward through the milestones.
+Always pass `-e`; there is one env per board. The boot log names the board an image was
+built for — check it first when a screen stays black.
 
 ## Roadmap (suggested milestones)
 - **M0 — Bring-up**: get the official HelloWorld/LVGL widgets demo running; copy verified databus + I2C pins into `config.h`. Backlight + touch + a "hello" screen.
@@ -93,5 +104,6 @@ First make the Waveshare `01_HelloWorld` equivalent light up, then bring this sc
 - Touch the shared aircraft vector only under `xSemaphoreTake(g_ac_mutex, ...)`.
 - All tunables live in `config.h`. No magic numbers in render code.
 - HTTPS: for a hobby device `WiFiClientSecure::setInsecure()` is acceptable; a pinned root cert is the "proper" option — note the choice in code.
-- **Never invent the unknown GPIO pins.** They come from the official demo. Placeholders are `-1` and the build should assert/log if they're still `-1`.
+- **Never invent GPIO pins.** They come from the official demo or the Arduino core's board variant, and must be confirmed on hardware (I2C scan + a full-panel test pattern) before being committed. Board headers assert at compile time if a pin is still `-1`.
+- **Anything board-specific belongs in `src/boards/`,** behind a `-DBOARD_*` flag — never hardcoded in a driver. Peripherals that a board lacks are compiled out via `BOARD_HAS_*` rather than left to fail at runtime.
 - API is non-commercial; keep request cadence gentle and User-Agent honest.

--- a/README.md
+++ b/README.md
@@ -47,14 +47,29 @@ A live **ADS-B aircraft radar** for the **Waveshare ESP32-S3-Touch-AMOLED-1.75**
 
 ## Hardware
 
-Waveshare **ESP32-S3-Touch-AMOLED-1.75**: ESP32-S3R8 (8 MB PSRAM, 16 MB flash), **CO5300** AMOLED over QSPI, **CST9217** touch, **QMI8658** IMU, **PCF85063** RTC, **AXP2101** PMIC, **ES8311** audio + speaker, microSD. All pins are in [`src/config.h`](src/config.h) (sourced from the board definition; no guessing).
+The reference board is the Waveshare **ESP32-S3-Touch-AMOLED-1.75**: ESP32-S3R8 (8 MB PSRAM, 16 MB flash), **CO5300** AMOLED over QSPI, **CST9217** touch, **QMI8658** IMU, **PCF85063** RTC, **AXP2101** PMIC, **ES8311** audio + speaker, microSD.
+
+The Waveshare **ESP32-S3-Touch-AMOLED-1.43** is also supported in-tree. Same SoC, same 466×466 CO5300 panel — but a completely different pin map, an **FT3168** touch controller, and no PMIC or audio codec (so no battery readout and no alert pings; everything else works).
+
+| | 1.75 (reference) | 1.43 |
+|---|---|---|
+| PlatformIO env | `esp32-s3-amoled-175` | `esp32-s3-amoled-143` |
+| QSPI CS / SCLK / D0–D3 | 12 / 38 / 4,5,6,7 | 9 / 10 / 11,12,13,14 |
+| LCD reset | 39 | 21 |
+| I2C SDA / SCL | 15 / 14 | 47 / 48 |
+| Touch | CST9217 @ 0x5A | FT3168 @ 0x38 |
+| Battery / audio | AXP2101 / ES8311 | not fitted |
+
+Pin maps live in [`src/boards/`](src/boards/), one header per board, selected by a `-DBOARD_*` build flag. They are taken from the vendor board definition and then **confirmed on hardware** — never guessed. Shared tunables stay in [`src/config.h`](src/config.h).
 
 ## Build & flash (PlatformIO)
 
 ```bash
-pio run -e esp32-s3-amoled-175 -t upload     # build + flash over USB-C
+pio run -e esp32-s3-amoled-175 -t upload     # build + flash over USB-C (1.75)
+pio run -e esp32-s3-amoled-143 -t upload     # ...or the 1.43
 pio device monitor -b 115200                  # serial log
 ```
+The boot log names the board it was built for (`Capsule Radar boot  fw … board …`) — worth checking first if the screen stays black, since the wrong board's image drives the wrong pins.
 On first flash you may need to hold **BOOT** then tap **RESET**. After flashing, on first boot connect your phone to the **`CapsuleRadar-Setup`** WiFi and enter your home network — real aircraft appear within seconds.
 
 ## Flash from your browser (no toolchain)
@@ -108,7 +123,7 @@ docs/                hardware / data-source / architecture notes
 
 ## Community ports & forks
 
-The reference board is the **Waveshare ESP32-S3-Touch-AMOLED-1.75**, but other boards are welcome upstream: a port contributed as a pull request (its own PlatformIO env + display layer) gets built by the CI on every release alongside the 1.75 — the 2.1" port below is on that path. Ports that prefer to stay independent live as forks, linked here (MIT: fork away, and tell me so I can add yours).
+The reference board is the **Waveshare ESP32-S3-Touch-AMOLED-1.75**, but other boards are welcome upstream: a port contributed as a pull request (its own PlatformIO env + board header in [`src/boards/`](src/boards/)) gets built by the CI on every release alongside the 1.75 — the in-tree **1.43** port is the worked example to copy, and the 2.1" port below is on that path. Ports that prefer to stay independent live as forks, linked here (MIT: fork away, and tell me so I can add yours).
 
 - **[Capsule Radar for the Waveshare ESP32-S3-Touch-LCD-2.1](https://github.com/alexzogh/capsule-radar/tree/port/esp32-s3-lcd-21)** by **@alexzogh (STLWarehouse)** — a full port to the 2.1" round LCD (ST7701), plus new features: **double-tap to track an aircraft** (scope re-centres on it), a **clock face on idle**, and the busy-airspace **query-radius fix** now merged back into this firmware. Ships its own binaries per release (files with `lcd21` in the name are the 2.1 builds).
 - **[Capsule Radar for the Waveshare 2.8" (non-touch)](https://github.com/ijord/capsule-radar)** by **@ijord** — port to the 2.8" ST7701 panel, with a smoother sweep compositor and the **PNG heap-corruption fix** that shipped upstream in v1.3.28. Thank you!

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -1,46 +1,101 @@
-# Hardware — Waveshare ESP32-S3-Touch-AMOLED-1.75
+# Hardware
 
-## Board
+Capsule Radar supports two Waveshare round-AMOLED boards. Both use the same SoC and
+the same 466×466 CO5300 panel, but their **pin maps have nothing in common** — flashing
+one board's image onto the other gives a black screen and a silent I2C bus.
+
+Pin maps live one-per-board in [`../src/boards/`](../src/boards/) and are selected by a
+build flag (see [`../src/config.h`](../src/config.h)):
+
+| Board | PlatformIO env | Build flag | Header |
+|---|---|---|---|
+| ESP32-S3-Touch-AMOLED-1.75 (reference) | `esp32-s3-amoled-175` | *(default)* | `board_amoled_175.h` |
+| ESP32-S3-Touch-AMOLED-1.43 | `esp32-s3-amoled-143` | `-DBOARD_AMOLED_143` | `board_amoled_143.h` |
+
+---
+
+## ESP32-S3-Touch-AMOLED-1.75 (reference board)
+
 - **MCU**: ESP32-S3R8 (Xtensa LX7 dual-core @240 MHz), 512 KB SRAM, **8 MB PSRAM**, **16 MB flash**.
 - **Wireless**: 2.4 GHz WiFi (b/g/n) + Bluetooth 5 (LE), onboard antenna (IPEX option).
-- **Display**: 1.75" AMOLED, **466×466**, 16.7M colors, driver **CO5300** over **QSPI**. Brightness set via panel command (no PWM backlight line).
-- **Touch**: **CST9217** capacitive, **I2C**. (Some units carry FT3168 — detect/abstract.)
-- **IMU**: **QMI8658** 6-axis (accel + gyro), I2C.
-- **RTC**: **PCF85063**, I2C (addr 0x51), kept alive by the PMIC.
-- **PMIC**: **AXP2101**, I2C (addr 0x34), LiPo charge + rails.
-- **Audio**: **ES8311** codec + onboard speaker (MX1.25 header); dual-mic array (ES7210 on the -C variant) with echo cancellation.
-- **Storage**: microSD (TF) slot.
-- **Buttons**: PWR + BOOT (programmable).
-- **Expansion**: 8-pin header = 3×GPIO + 1×UART, plus reserved I2C/IO pads.
-- **GPS** (only on the `-G` variant): LC76G + external ceramic antenna.
+- **Display**: 1.75" AMOLED, **466×466**, driver **CO5300** over **QSPI**. Brightness via panel command (no PWM backlight line).
+- **Touch**: **CST9217** capacitive, I2C.
+- **IMU**: **QMI8658** 6-axis, I2C. **RTC**: **PCF85063**, I2C.
+- **PMIC**: **AXP2101**, I2C — LiPo charge + rails.
+- **Audio**: **ES8311** codec + onboard speaker; dual-mic array (ES7210 on the -C variant).
+- **Storage**: microSD (TF). **Buttons**: PWR + BOOT. **GPS** (`-G` variant only): LC76G.
 
-## Pin map
-### Verified (from the board's ESPHome definition)
-| Signal            | GPIO | Notes                         |
-|-------------------|------|-------------------------------|
-| LCD CS            | 12   | CO5300, QSPI                  |
-| LCD RST           | 39   | CO5300                        |
-| Touch INT         | 11   | CST9217                       |
-| Touch RST         | 40   | CST9217                       |
-| Touch transform   | —    | mirror_x = true, mirror_y = true |
+| Signal | GPIO | | Signal | GPIO |
+|---|---|---|---|---|
+| LCD CS | 12 | | I2C SDA | 15 |
+| LCD RST | 39 | | I2C SCL | 14 |
+| LCD QSPI SCLK | 38 | | I2S MCLK | 42 |
+| LCD QSPI D0–D3 | 4, 5, 6, 7 | | I2S BCLK | 9 |
+| Touch INT | 11 | | I2S LRCLK | 45 |
+| Touch RST | 40 | | I2S DOUT / DIN | 8 / 10 |
+| Touch transform | mirror_x + mirror_y | | Speaker amp enable | 46 |
 
-### To confirm from the official Waveshare Arduino demo (do NOT guess)
-| Signal              | GPIO | Where to find it                 |
-|---------------------|------|----------------------------------|
-| LCD QSPI SCLK       | ?    | demo `01_HelloWorld` (Arduino_GFX_DataBus) |
-| LCD QSPI D0..D3     | ?    | demo `01_HelloWorld`             |
-| I2C SDA (shared)    | ?    | any LVGL+sensor demo (`03`/`04`) |
-| I2C SCL (shared)    | ?    | any LVGL+sensor demo             |
-| Speaker / I2S (ES8311) | ? | demo `08_ES8311`                 |
+Panel column gap **6**, row gap 0, QSPI clock 80 MHz.
+I2C: CST9217 `0x5A`, QMI8658 `0x6B`, PCF85063 `0x51`, AXP2101 `0x34`, ES8311 `0x18`.
 
-Touch, IMU, RTC, PMIC share one I2C bus. Pull pins from the demos into `src/config.h`; the placeholders there are `-1`.
+Sources: the board's ESPHome definition, the Waveshare board definition in xiaozhi-esp32,
+and a working Arduino_GFX port for this panel.
 
-## I2C addresses (typical)
-- CST9217 touch: 0x15 (verify)
-- QMI8658 IMU: 0x6B (or 0x6A)
-- PCF85063 RTC: 0x51
-- AXP2101 PMIC: 0x34
+---
+
+## ESP32-S3-Touch-AMOLED-1.43
+
+Same 466×466 CO5300 panel, 8 MB PSRAM / 16 MB flash. Differences that matter:
+
+- **Touch is an FT3168**, not a CST9217, at a different address and with a different protocol.
+- **No AXP2101 and no ES8311** — no battery reporting and no alert pings. Both compile out
+  via `BOARD_HAS_PMIC` / `BOARD_HAS_AUDIO`. This is not merely cosmetic: the 1.75's I2S
+  BCLK/DIN (GPIO 9/10) are *this* board's QSPI CS and SCLK, so leaving audio enabled here
+  would drive the panel's own bus lines.
+- The FT3168 has **no reset line of its own**; it is tied to the panel reset (GPIO 21) and
+  does not appear on I2C at all until the display has been initialised. `display::begin()`
+  therefore must keep `gfx->begin()` ahead of `touch_begin()`.
+- IMU and RTC are the same parts at the same addresses as the 1.75.
+
+| Signal | GPIO | | Signal | GPIO |
+|---|---|---|---|---|
+| LCD CS | 9 | | I2C SDA | 47 |
+| LCD RST | 21 | | I2C SCL | 48 |
+| LCD QSPI SCLK | 10 | | Touch INT / RST | not broken out |
+| LCD QSPI D0–D3 | 11, 12, 13, 14 | | Touch transform | none (raw coords match) |
+| Battery ADC | 4 (unused — see below) | | IMU INT / RTC INT | 8 / 15 |
+
+Panel column gap **6** (same as the 1.75), row gap 0, QSPI clock 40 MHz (the vendor rate;
+80 MHz is untested here).
+I2C: FT3168 `0x38` (chip-id register `0xA3` reads `0x64`), QMI8658 `0x6B`, PCF85063 `0x51`.
+
+Battery: there is a divided battery voltage on GPIO 4, but the divider ratio is not
+documented, so the firmware reports "no battery" rather than an invented percentage.
+
+**Sources.** Pins come from the Arduino-ESP32 core's own board variant
+(`variants/waveshare_esp32_s3_touch_amoled_143/pins_arduino.h`, shared with the 1.64), and
+each was then confirmed on hardware: an I2C scan on 47/48 answers `0x51` + `0x6B` + `0x38`,
+and the panel drives correctly on CS=9 / SCK=10 / D0–D3=11–14 / RST=21. The touch orientation
+was verified with an on-screen dot tracking a fingertip, and the column gap by nudging a
+full-panel rim-ring test card one pixel at a time until it centred.
+
+> Do **not** "correct" these against the Waveshare wiki pin table: that table is misaligned
+> and lists an I2C SCL of GPIO 49, which does not exist on an ESP32-S3.
+
+---
+
+## Adding another board
+
+1. Copy a header in `src/boards/`, fill in the pins **from the vendor demo or the Arduino
+   core board variant** — never guess them.
+2. Add an `[env:…]` in `platformio.ini` that `extends = amoled_common` and sets `-DBOARD_…`.
+3. Set `BOARD_HAS_PMIC` / `BOARD_HAS_AUDIO` / `TOUCH_DRIVER_…` for what is actually fitted;
+   add a touch driver alongside `touch_cst9217.cpp` / `touch_ft3168.cpp` if needed.
+4. Confirm on hardware before committing: I2C scan, a full-panel test pattern for the gap,
+   and a touch dot that lands under your fingertip.
+5. Add the env to `.github/workflows/release.yml` so it ships with every release.
 
 ## Reference
-Waveshare wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.75
-ESPHome device page (pin source): https://devices.esphome.io/devices/waveshare-esp32-s3-touch-amoled-175/
+- 1.75 wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.75
+- 1.43 wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.43
+- ESPHome device page (1.75 pin source): https://devices.esphome.io/devices/waveshare-esp32-s3-touch-amoled-175/

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -5,19 +5,29 @@
 - USB-C cable. On first flash you may need to hold **BOOT** then tap **PWR/RST**.
 
 ## PlatformIO
+Always pass `-e`: there is one environment per supported board (plus the desktop simulator).
 ```
-pio run                      # build
-pio run -t upload            # flash
+pio run -e esp32-s3-amoled-175            # build for the 1.75 (reference board)
+pio run -e esp32-s3-amoled-143            # build for the 1.43
+pio run -e esp32-s3-amoled-175 -t upload  # flash over USB-C
 pio device monitor -b 115200
 ```
+The boot log states which board the image was built for:
+`Capsule Radar boot  fw 1.4.0  board ESP32-S3-Touch-AMOLED-1.43`. If the screen stays
+black, check that line first — the boards' pin maps are completely different, so the
+wrong image drives the wrong GPIOs and shows nothing.
 
-## Bring-up order (important)
-1. Clone the Waveshare factory Arduino demos from the wiki:
-   https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.75
-2. Build & flash `01_HelloWorld`. Confirm the screen lights up.
-3. **Copy the exact pins** (QSPI SCLK/D0..D3, I2C SDA/SCL, ES8311 I2S) from those demos into `src/config.h` (replace the `-1` placeholders).
-4. Build `06_LVGL_Widgets` and copy its working **`lv_conf.h`** into this project's include path (we set `-DLV_CONF_INCLUDE_SIMPLE`). Match the LVGL major version in `platformio.ini` to that demo.
-5. Now build this project and proceed through the milestones in `CLAUDE.md`.
+## Bringing up a new board
+Pins for the two supported boards are already confirmed and live in `src/boards/`; you
+only need this if you are porting to a third board. See "Adding another board" in
+[HARDWARE.md](HARDWARE.md).
+
+1. Take the pins from the vendor's factory Arduino demos (`01_HelloWorld` gives the QSPI
+   databus, `03`/`04` give the shared I2C) **or** from the Arduino-ESP32 core's board
+   variant in `~/.platformio/packages/framework-arduinoespressif32/variants/`. Do not guess.
+2. Confirm them on hardware before committing: an I2C scan should name the parts you
+   expect, and a full-panel test pattern should fill the panel edge to edge.
+3. Build `06_LVGL_Widgets` and copy its working **`lv_conf.h`** into this project's include path (we set `-DLV_CONF_INCLUDE_SIMPLE`). Match the LVGL major version in `platformio.ini` to that demo.
 
 ## lv_conf.h
 LVGL needs `lv_conf.h` reachable on the include path. Easiest: copy from the Waveshare `06_LVGL_Widgets` demo (it's already tuned for this panel/color depth), set `LV_COLOR_DEPTH 16`, enable PSRAM draw buffers, and keep the QMI8658/touch indev wiring from demos `03/04`.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,18 +1,23 @@
-; Capsule Radar — Waveshare ESP32-S3-Touch-AMOLED-1.75
+; Capsule Radar
 ;
-; Two environments:
-;   esp32-s3-amoled-175  -> real firmware (Arduino_GFX + LVGL), flashed to the board
+; Environments:
+;   esp32-s3-amoled-175  -> firmware for the reference Waveshare ESP32-S3-Touch-AMOLED-1.75
+;   esp32-s3-amoled-143  -> firmware for the Waveshare ESP32-S3-Touch-AMOLED-1.43
 ;   native               -> desktop LVGL simulator (SDL2), runs the same UI on the Mac
+;
+; The two board envs share everything except a -DBOARD_* flag; the pin map, panel
+; gaps, touch driver and peripheral set live in src/boards/board_*.h.
 ;
 ; Build/run the simulator:   pio run -e native -t exec
 ; Build/flash the device:    pio run -e esp32-s3-amoled-175 -t upload
+;                            pio run -e esp32-s3-amoled-143 -t upload
 
-[env:esp32-s3-amoled-175]
+[amoled_common]
 ; pioarduino fork of the espressif32 platform (Arduino core 3.x / ESP-IDF 5.x).
 ; This exact release is what the reference board builds use and is already installed
 ; locally; swap to "espressif32" (registry) if you prefer the official platform.
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip
-board = esp32-s3-devkitc-1      ; generic S3; matches ESP32-S3R8 (8MB PSRAM / 16MB flash)
+board = esp32-s3-devkitc-1      ; generic S3; both boards are 8MB PSRAM / 16MB flash
 framework = arduino
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
@@ -58,10 +63,30 @@ lib_deps =
 ; - lv_conf.h lives in include/ (added to the include path above).
 ; - Versions are pinned to a known-good combination for this panel; bump deliberately.
 
+; --- Board: Waveshare ESP32-S3-Touch-AMOLED-1.75 (reference) -----------------
+[env:esp32-s3-amoled-175]
+extends = amoled_common
+; no -DBOARD_* flag: src/config.h defaults to the 1.75 board header.
+
+; --- Board: Waveshare ESP32-S3-Touch-AMOLED-1.43 -----------------------------
+; Same SoC, PSRAM and flash as the 1.75, but a different pin map, an FT3168 touch
+; controller instead of the CST9217, and no PMIC/audio codec. See
+; src/boards/board_amoled_143.h -- those pins are confirmed on hardware.
+[env:esp32-s3-amoled-143]
+extends = amoled_common
+build_flags =
+    ${amoled_common.build_flags}
+    -DBOARD_AMOLED_143
+
 ; --- OTA upload (flash over WiFi) -------------------------------------------
 ; Device must be powered and on WiFi. Then:  pio run -e esp32-s3-amoled-175-ota -t upload
 [env:esp32-s3-amoled-175-ota]
 extends = env:esp32-s3-amoled-175
+upload_protocol = espota
+upload_port = capsuleradar.local
+
+[env:esp32-s3-amoled-143-ota]
+extends = env:esp32-s3-amoled-143
 upload_protocol = espota
 upload_port = capsuleradar.local
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -7,7 +7,13 @@
 // that table is board-specific, the rest is independent.
 #include "audio.h"
 #include "config.h"
+
 #include <Arduino.h>
+
+// Boards without an ES8311 (e.g. the 1.43) compile to no-ops. This is not just
+// dead weight: that board reuses GPIO 9/10 -- the 1.75's I2S BCLK/DIN -- as the
+// panel's QSPI CS and SCLK, so configuring I2S here would break the display.
+#if BOARD_HAS_AUDIO
 #include <Wire.h>
 #include "driver/i2s.h"
 #include "esp_heap_caps.h"
@@ -231,3 +237,14 @@ void audio_selftest() {   // ~2 s continuous tone, ignores mute, PA held on
     s_cue = 2;
     if (s_sem) xSemaphoreGive(s_sem);
 }
+
+#else   // !BOARD_HAS_AUDIO
+
+bool audio_begin()              { Serial.println("[audio] no codec on this board"); return false; }
+bool audio_present()            { return false; }
+void audio_set_volume(int)      {}
+void audio_set_muted(bool)      {}
+void audio_play(AudioCue)       {}
+void audio_selftest()           {}
+
+#endif  // BOARD_HAS_AUDIO

--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -2,7 +2,14 @@
 // read it from the LVGL loop (core 1), not the network task.
 #include "battery.h"
 #include "config.h"
+
 #include <Arduino.h>
+
+// Boards without an AXP2101 (e.g. the 1.43) compile to no-ops and simply report
+// "no battery", which the UI already handles. That board does bring a divided
+// battery voltage out on PIN_BAT_ADC, but the divider ratio is undocumented, so
+// no percentage is reported rather than an invented one.
+#if BOARD_HAS_PMIC
 #include <Wire.h>
 #define XPOWERS_CHIP_AXP2101
 #include "XPowersLib.h"
@@ -32,3 +39,13 @@ void battery_enable_codec_rail() {
     PMU.enableALDO1();
     Serial.println("[batt] ALDO1 (codec AVDD) enabled @3.3V");
 }
+
+#else   // !BOARD_HAS_PMIC
+
+bool battery_begin()   { Serial.println("[batt] no PMIC on this board"); return false; }
+bool battery_present() { return false; }
+int  battery_percent() { return -1; }
+bool battery_charging(){ return false; }
+void battery_enable_codec_rail() {}
+
+#endif  // BOARD_HAS_PMIC

--- a/src/boards/board_amoled_143.h
+++ b/src/boards/board_amoled_143.h
@@ -1,0 +1,64 @@
+#pragma once
+// Board: Waveshare ESP32-S3-Touch-AMOLED-1.43.
+// ESP32-S3-PICO (8 MB PSRAM / 16 MB flash), CO5300 466x466 AMOLED (QSPI),
+// FT3168 touch, QMI8658 IMU, PCF85063 RTC.  No PMIC and no audio codec.
+//
+// Same panel size and controller as the 1.75, but a COMPLETELY different pin map --
+// flashing the 1.75 build here gives a black screen and a silent I2C bus.
+//
+// Pins come from the Arduino-ESP32 core's own board variant
+// (variants/waveshare_esp32_s3_touch_amoled_143/pins_arduino.h, which the 1.64 board
+// shares), and every one of them was then confirmed on real hardware:
+//   - I2C scan on 47/48 answers 0x51 (PCF85063) + 0x6B (QMI8658) + 0x38 (FT3168)
+//   - the panel drives correctly on CS=9 SCK=10 D0..D3=11..14 RST=21
+// Do not "tidy" these against the Waveshare wiki pin table: that table is misaligned
+// (it lists an I2C SCL of GPIO49, which does not exist on an ESP32-S3).
+
+#define BOARD_NAME          "ESP32-S3-Touch-AMOLED-1.43"
+#define BOARD_PIO_ENV       "esp32-s3-amoled-143"   // used in the OTA hint printed at boot
+
+// ---------- Panel ----------
+#define PIN_LCD_CS          9
+#define PIN_LCD_RST         21
+#define PIN_LCD_SCLK        10             // QSPI PCLK
+#define PIN_LCD_D0          11
+#define PIN_LCD_D1          12
+#define PIN_LCD_D2          13
+#define PIN_LCD_D3          14
+// Same gap as the 1.75: the CO5300 has a 480-wide RAM behind a 466-wide panel.
+// Dialled in on hardware with a pixel-accurate nudge tool (full frame composed in
+// PSRAM and blitted in one aligned window, so a 1px step really is 1px); 6 centres
+// the image, 7 and 8 visibly overshoot.
+#define LCD_COL_OFFSET      6
+#define LCD_ROW_OFFSET      0
+#define LCD_QSPI_HZ         40000000       // vendor rate; verified. 80 MHz is untested here.
+
+// ---------- Shared I2C (touch + IMU + RTC) ----------
+#define PIN_I2C_SDA         47
+#define PIN_I2C_SCL         48
+
+// ---------- Touch ----------
+// The FT3168 has no dedicated reset line broken out: its reset is tied to the panel
+// reset (GPIO21), so it only appears on the bus AFTER the LCD has been initialised.
+// display::begin() already calls gfx->begin() before touch_begin(), which is what
+// makes this work -- do not reorder those two.
+#define TOUCH_DRIVER_FT3168 1
+#define I2C_ADDR_TOUCH      0x38           // confirmed; chip id reg 0xA3 reads 0x64
+#define PIN_TP_INT          -1             // not broken out
+#define PIN_TP_RST          -1             // shared with PIN_LCD_RST
+// Raw controller coordinates already match the panel orientation (verified: the
+// on-screen dot lands under the fingertip, x spans 24..443, y spans 0..459).
+#define TP_MIRROR_X         false
+#define TP_MIRROR_Y         false
+
+// ---------- Peripherals ----------
+// No AXP2101 and no ES8311 on this board (an I2C scan finds neither). Battery level
+// is instead a divided analog reading on GPIO4, but the divider ratio is not
+// documented, so battery reporting stays off rather than showing an invented number.
+#define BOARD_HAS_PMIC      0
+#define BOARD_HAS_AUDIO     0
+#define PIN_BAT_ADC         4              // unused for now; see note above
+#define I2C_ADDR_IMU        0x6B
+#define I2C_ADDR_RTC        0x51
+
+#define PIN_BOOT_BUTTON     0

--- a/src/boards/board_amoled_175.h
+++ b/src/boards/board_amoled_175.h
@@ -1,0 +1,51 @@
+#pragma once
+// Board: Waveshare ESP32-S3-Touch-AMOLED-1.75 (the reference board).
+// ESP32-S3R8, 8 MB PSRAM / 16 MB flash, CO5300 466x466 AMOLED (QSPI),
+// CST9217 touch, QMI8658 IMU, PCF85063 RTC, AXP2101 PMIC, ES8311 audio.
+//
+// Pins verified against the ESPHome definition, the Waveshare board definition in
+// xiaozhi-esp32, and a working Arduino_GFX port for this exact panel.
+
+#define BOARD_NAME          "ESP32-S3-Touch-AMOLED-1.75"
+#define BOARD_PIO_ENV       "esp32-s3-amoled-175"   // used in the OTA hint printed at boot
+
+// ---------- Panel ----------
+#define PIN_LCD_CS          12
+#define PIN_LCD_RST         39
+#define PIN_LCD_SCLK        38             // QSPI PCLK
+#define PIN_LCD_D0          4
+#define PIN_LCD_D1          5
+#define PIN_LCD_D2          6
+#define PIN_LCD_D3          7
+#define LCD_COL_OFFSET      6              // CO5300 column (x) gap on this panel (esp_lcd set_gap 0x06)
+#define LCD_ROW_OFFSET      0              // no row (y) gap
+#define LCD_QSPI_HZ         80000000       // CO5300 QSPI clock (vendor uses 40 MHz; 80 = faster, verify no artifacts)
+
+// ---------- Shared I2C (touch + IMU + RTC + PMIC + audio codec) ----------
+#define PIN_I2C_SDA         15
+#define PIN_I2C_SCL         14
+
+// ---------- Touch ----------
+#define TOUCH_DRIVER_CST9217 1
+#define I2C_ADDR_TOUCH      0x5A           // CST9217 (corrected from vendor driver; was 0x15)
+#define PIN_TP_INT          11
+#define PIN_TP_RST          40
+#define TP_MIRROR_X         true
+#define TP_MIRROR_Y         true
+
+// ---------- Peripherals present on this board ----------
+#define BOARD_HAS_PMIC      1              // AXP2101 battery gauge
+#define BOARD_HAS_AUDIO     1              // ES8311 codec + speaker
+#define I2C_ADDR_IMU        0x6B
+#define I2C_ADDR_RTC        0x51
+#define I2C_ADDR_PMIC       0x34
+
+// ---------- ES8311 codec over I2S (M4 alert ping) ----------
+#define PIN_I2S_MCLK        42
+#define PIN_I2S_BCLK        9
+#define PIN_I2S_LRCLK       45             // a.k.a. WS
+#define PIN_I2S_DOUT        8              // ESP32 -> codec (speaker)
+#define PIN_I2S_DIN         10             // codec -> ESP32 (mics)
+#define PIN_AUDIO_PA        46             // speaker amp enable
+
+#define PIN_BOOT_BUTTON     0              // BOOT button (held on boot = captive portal, later)

--- a/src/config.h
+++ b/src/config.h
@@ -1,9 +1,7 @@
 #pragma once
 // Capsule Radar — build & user configuration.
 
-#define FW_VERSION "1.3.29"   // shown on the web config page + Stats screen; bump on release
-// Edit pins below: replace every -1 with the value from the Waveshare factory demo
-// (see docs/HARDWARE.md and docs/SETUP.md). Do NOT guess them.
+#define FW_VERSION "1.4.0"   // shown on the web config page + Stats screen; bump on release
 
 // ---------- Home location (default: Dénia, Spain) ----------
 // Overridable at runtime via the captive portal (stored in NVS).
@@ -30,16 +28,14 @@ static const float RANGE_STEPS_KM[] = {10.0f, 20.0f, 30.0f, 50.0f, 100.0f};
 #define WX_RADAR_REFRESH_MS 300000UL       // RainViewer frames update about every 5 minutes
 #define CLOUD_IMAGE_REFRESH_MS 600000UL    // EUMETSAT MTG cloud imagery; cache for 10 minutes
 
-// ---------- Screen (CO5300 AMOLED) ----------
+// ---------- Screen (CO5300 AMOLED, 466x466 on every supported board) ----------
 #define SCREEN_W            466
 #define SCREEN_H            466
 #define SCREEN_CX           233
 #define SCREEN_CY           233
 #define RADAR_R_OUTER_PX    218            // outer ring radius in pixels
 #define LV_COLOR_DEPTH_BITS 16
-#define LCD_COL_OFFSET      6              // CO5300 column (x) gap on this panel (esp_lcd set_gap 0x06)
-#define LCD_ROW_OFFSET      0              // no row (y) gap
-#define LCD_QSPI_HZ         80000000       // CO5300 QSPI clock (vendor uses 40 MHz; 80 = faster, verify no artifacts)
+// LCD_COL_OFFSET / LCD_ROW_OFFSET / LCD_QSPI_HZ are panel-specific -> board header.
 #define BRIGHTNESS_DEFAULT  200            // 0..255, panel brightness via cmd 0x51
 #define TZ_STR              "CET-1CEST,M3.5.0,M10.5.0/3"  // POSIX TZ (Spain) for local time/date
 #define BRIGHTNESS_IDLE     25             // dimmed after no touch for IDLE_DIM_MS
@@ -55,43 +51,21 @@ static const float RANGE_STEPS_KM[] = {10.0f, 20.0f, 30.0f, 50.0f, 100.0f};
 // ---------- Debug ----------
 #define DEBUG_MEM           0               // 1 = print a [mem] heap/fps line every 5s on serial
 
-// ---------- Pin map ----------
-// VERIFIED (ESPHome def, cross-checked against the Waveshare board definition in
-// xiaozhi-esp32 and a working Arduino_GFX port for this exact panel):
-#define PIN_LCD_CS          12
-#define PIN_LCD_RST         39
-#define PIN_TP_INT          11
-#define PIN_TP_RST          40
-#define TP_MIRROR_X         true
-#define TP_MIRROR_Y         true
+// ---------- Board ----------
+// The pin map, panel gaps, touch driver and which peripherals exist all live in a
+// per-board header. Select one with a build flag in platformio.ini; the 1.75 is the
+// default so an unflagged build behaves exactly as before.
+//   -DBOARD_AMOLED_143  -> Waveshare ESP32-S3-Touch-AMOLED-1.43
+//   (none)              -> Waveshare ESP32-S3-Touch-AMOLED-1.75  (reference board)
+// Never guess pins for a new board: take them from the vendor demo or the Arduino
+// core board variant, then confirm them on hardware before committing.
+#if defined(BOARD_AMOLED_143)
+#  include "boards/board_amoled_143.h"
+#else
+#  include "boards/board_amoled_175.h"
+#endif
 
-// CONFIRMED — CO5300 QSPI databus (LCD_CS=12, LCD_RST=39 above match too):
-#define PIN_LCD_SCLK        38             // QSPI PCLK
-#define PIN_LCD_D0          4
-#define PIN_LCD_D1          5
-#define PIN_LCD_D2          6
-#define PIN_LCD_D3          7
-
-// CONFIRMED — shared I2C bus (touch + IMU + RTC + PMIC + audio codec):
-#define PIN_I2C_SDA         15
-#define PIN_I2C_SCL         14
-
-// CONFIRMED — ES8311 codec over I2S (M4 alert ping). MCLK/DIN/PA included for completeness:
-#define PIN_I2S_MCLK        42
-#define PIN_I2S_BCLK        9
-#define PIN_I2S_LRCLK       45             // a.k.a. WS
-#define PIN_I2S_DOUT        8              // ESP32 -> codec (speaker)
-#define PIN_I2S_DIN         10             // codec -> ESP32 (mics)
-#define PIN_AUDIO_PA        46             // speaker amp enable
-#define PIN_BOOT_BUTTON     0              // BOOT button (held on boot = captive portal, later)
-
-// I2C addresses:
-#define I2C_ADDR_TOUCH      0x5A           // CST9217 (corrected from vendor driver; was 0x15)
-#define I2C_ADDR_IMU        0x6B
-#define I2C_ADDR_RTC        0x51
-#define I2C_ADDR_PMIC       0x34
-
-// Safety net: should never fire now that pins are filled in. Keeps future edits honest.
+// Safety net: catches a board header that still has placeholder pins in it.
 #if (PIN_LCD_SCLK < 0) || (PIN_I2C_SDA < 0)
-#  error "config.h: QSPI/I2C pins are back to placeholders (-1). Restore the real values."
+#  error "board header: QSPI/I2C pins are placeholders (-1). Fill in the real values."
 #endif

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,13 +1,15 @@
 // M0 bring-up: CO5300 466x466 AMOLED via Arduino_GFX (QSPI) + LVGL.
-// Pins come from config.h (confirmed against the Waveshare board definition and a
-// working Arduino_GFX port for this exact panel). The panel runs off the always-on
-// DC1 rail, so it lights up without configuring the AXP2101 PMIC.
+// Pins, panel gaps and the touch driver all come from the board header selected in
+// config.h (see src/boards/). On boards with an AXP2101 the panel runs off the
+// always-on DC1 rail, so it lights up without configuring the PMIC first.
+// NOTE: gfx->begin() must stay ahead of touch_begin() — on the 1.43 the touch
+// controller's reset is tied to the panel reset and it is absent from I2C until then.
 // The actual UI is built by ui_boot_create() (shared with the native SDL sim).
 #include "display.h"
 #include "config.h"
 #include "radar_view.h"
 #include "ui.h"
-#include "touch_cst9217.h"
+#include "touch.h"
 
 #include <Arduino.h>
 #include <Arduino_GFX_Library.h>
@@ -291,7 +293,7 @@ bool begin() {
         s_indev_drv.type = LV_INDEV_TYPE_POINTER;
         s_indev_drv.read_cb = touch_read_cb;
         lv_indev_drv_register(&s_indev_drv);
-        Serial.println("[display] CST9217 touch registered");
+        Serial.println("[display] touch registered (" BOARD_NAME ")");
     }
 
     Serial.printf("[display] PSRAM free: %u KB\n", (unsigned)(ESP.getFreePsram() / 1024));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -940,7 +940,7 @@ static void handleUpdateUpload() {
 void setup() {
     Serial.begin(115200);
     delay(200);
-    Serial.println("\nCapsule Radar boot");
+    Serial.println("\nCapsule Radar boot  fw " FW_VERSION "  board " BOARD_NAME);
 
     if (PIN_LCD_SCLK < 0 || PIN_I2C_SDA < 0) {
         Serial.println("[!] Pins in config.h are still -1. Copy them from the Waveshare demo.");
@@ -1127,7 +1127,7 @@ void loop() {
         ArduinoOTA.begin();
         MDNS.addService("http", "tcp", 80);            // advertise the config web page
         otaUp = true;
-        Serial.println("[ota] ready: pio run -e esp32-s3-amoled-175-ota -t upload");
+        Serial.println("[ota] ready: pio run -e " BOARD_PIO_ENV "-ota -t upload");
     }
     if (otaUp) ArduinoOTA.handle();
 

--- a/src/touch.h
+++ b/src/touch.h
@@ -1,0 +1,9 @@
+#pragma once
+// Capacitive touch, board-neutral interface. Device-only.
+// Exactly one driver compiles per build, chosen by the board header:
+//   TOUCH_DRIVER_CST9217 -> touch_cst9217.cpp  (1.75)
+//   TOUCH_DRIVER_FT3168  -> touch_ft3168.cpp   (1.43)
+#include <stdint.h>
+
+bool touch_begin();                        // I2C + reset; logs comms status
+bool touch_read(uint16_t *x, uint16_t *y); // true if currently pressed (x,y in screen px)

--- a/src/touch_cst9217.cpp
+++ b/src/touch_cst9217.cpp
@@ -1,8 +1,10 @@
 // CST9217 capacitive touch over I2C (Arduino). Ported from Waveshare's
 // esp_lcd_touch_cst9217: read 10 bytes from reg 0xD000, validate ACK 0xAB,
 // unpack the 12-bit X/Y of the first touch point. Single-touch is enough here.
-#include "touch_cst9217.h"
+#include "touch.h"
 #include "config.h"
+
+#if TOUCH_DRIVER_CST9217
 #include <Arduino.h>
 #include <Wire.h>
 
@@ -64,3 +66,5 @@ bool touch_read(uint16_t *ox, uint16_t *oy) {
     *oy = y;
     return true;
 }
+
+#endif  // TOUCH_DRIVER_CST9217

--- a/src/touch_cst9217.h
+++ b/src/touch_cst9217.h
@@ -1,7 +1,0 @@
-#pragma once
-// Minimal Arduino driver for the CST9217 capacitive touch (I2C). Device-only.
-// Protocol ported from Waveshare's esp_lcd_touch_cst9217 component.
-#include <stdint.h>
-
-bool touch_begin();                       // I2C + hardware reset; logs comms status
-bool touch_read(uint16_t *x, uint16_t *y); // true if currently pressed (x,y in screen px)

--- a/src/touch_ft3168.cpp
+++ b/src/touch_ft3168.cpp
@@ -1,0 +1,66 @@
+// FT3168 capacitive touch over I2C (Arduino) — Waveshare ESP32-S3-Touch-AMOLED-1.43.
+// Standard FocalTech register layout: one burst read from 0x00 gives the touch count
+// and the 12-bit X/Y of the first point. Single-touch is all the radar UI needs.
+//
+// This chip has no reset line of its own on this board — it is wired to the panel
+// reset — so it only answers on I2C once the display has been initialised. That is
+// why display::begin() must call gfx->begin() before touch_begin(); with the stock
+// 1.75 firmware's pin map nothing on the bus answered at all.
+#include "touch.h"
+#include "config.h"
+
+#if TOUCH_DRIVER_FT3168
+#include <Arduino.h>
+#include <Wire.h>
+
+#define FT_REG_DATA     0x00       // burst: [mode][gest][count][xh][xl][yh][yl]
+#define FT_REG_CHIPID   0xA3       // reads 0x64 on the FT3168
+#define FT_DATA_LEN     7
+#define FT_CHIPID_FT3168 0x64
+
+#define FT_EVT_LIFT_UP  1          // top 2 bits of the xh byte
+
+static bool ft_read_reg(uint8_t reg, uint8_t *data, uint8_t len) {
+    Wire.beginTransmission((uint8_t)I2C_ADDR_TOUCH);
+    Wire.write(reg);
+    if (Wire.endTransmission(false) != 0) return false;   // repeated START
+    if (Wire.requestFrom((uint8_t)I2C_ADDR_TOUCH, len) < len) return false;
+    for (uint8_t i = 0; i < len; ++i) data[i] = Wire.read();
+    return true;
+}
+
+bool touch_begin() {
+    Wire.begin(PIN_I2C_SDA, PIN_I2C_SCL, 400000);
+
+    uint8_t id[1] = {0};
+    if (ft_read_reg(FT_REG_CHIPID, id, 1) && id[0] == FT_CHIPID_FT3168) {
+        Serial.println("[touch] FT3168 responding (chip id 0x64)");
+    } else {
+        // Not fatal: the panel reset may still be settling. touch_read() retries forever.
+        Serial.printf("[touch] FT3168 not responding yet (id=0x%02X, will keep polling)\n", id[0]);
+    }
+    return true;
+}
+
+bool touch_read(uint16_t *ox, uint16_t *oy) {
+    uint8_t d[FT_DATA_LEN];
+    if (!ft_read_reg(FT_REG_DATA, d, FT_DATA_LEN)) return false;
+
+    const uint8_t points = d[2] & 0x0F;
+    if (points == 0 || points > 5) return false;          // 0x0F = no valid data
+    if ((d[3] >> 6) == FT_EVT_LIFT_UP) return false;      // finger leaving, treat as released
+
+    uint16_t x = (uint16_t)((d[3] & 0x0F) << 8 | d[4]);
+    uint16_t y = (uint16_t)((d[5] & 0x0F) << 8 | d[6]);
+
+    if (x > SCREEN_W - 1) x = SCREEN_W - 1;
+    if (y > SCREEN_H - 1) y = SCREEN_H - 1;
+    if (TP_MIRROR_X) x = (SCREEN_W - 1) - x;
+    if (TP_MIRROR_Y) y = (SCREEN_H - 1) - y;
+
+    *ox = x;
+    *oy = y;
+    return true;
+}
+
+#endif  // TOUCH_DRIVER_FT3168


### PR DESCRIPTION
Adds the **Waveshare ESP32-S3-Touch-AMOLED-1.43** as a second in-tree board, following the
"own PlatformIO env + board layer" route in the README. Same SoC and the same 466×466 CO5300
panel as the 1.75 — but not one pin in common, so the stock image gives a black screen and an
I2C bus on which nothing answers at all.

Everything below was brought up on a real unit; nothing is taken on trust from the wiki.

## The 1.75 is untouched

- Its pin map and comments move into `src/boards/board_amoled_175.h` **verbatim** — I checked
  this with a diff of the `#define`s against the old `config.h`, not by eye.
- There is **no `-DBOARD_*` flag on the 1.75 env**: an unflagged build still selects the 1.75
  header, so existing builds, CI and instructions behave exactly as before.
- The only 1.75 behaviour change is two log lines that used to hardcode the board: the boot
  banner now names the board, and the OTA hint prints the right env for the image you flashed.

## What differs on the 1.43

| | 1.75 | 1.43 |
|---|---|---|
| QSPI CS / SCLK / D0–D3 | 12 / 38 / 4,5,6,7 | 9 / 10 / 11,12,13,14 |
| LCD reset | 39 | 21 |
| I2C SDA / SCL | 15 / 14 | 47 / 48 |
| Touch | CST9217 @ 0x5A | FT3168 @ 0x38 |
| PMIC / audio | AXP2101 / ES8311 | neither fitted |
| Panel column gap | 6 | 6 (same) |

Touch is now behind a board-neutral `touch.h`, with one driver compiled in per build
(`touch_cst9217.cpp` / `touch_ft3168.cpp`). Absent peripherals compile out via
`BOARD_HAS_PMIC` / `BOARD_HAS_AUDIO`.

## Two things worth not rediscovering the hard way

**The FT3168's reset is tied to the panel reset.** It has no reset line of its own, so it is
absent from I2C entirely until the display has been initialised. `display::begin()` must keep
`gfx->begin()` ahead of `touch_begin()` — there's a comment on both sides, because a future
reorder would look harmless and silently kill touch.

**Audio must stay compiled out here, not merely fail to detect.** The 1.75's I2S BCLK/DIN
(GPIO 9/10) are *this* board's QSPI CS and SCLK. Letting `audio_begin()` run and fail would
configure I2S on the panel's own bus lines.

Also: the Waveshare wiki pin table for this board is misaligned — it lists an I2C SCL of
GPIO 49, which does not exist on an ESP32-S3. There's a warning in the header so nobody
"corrects" the working pins to match it.

## How the pins were established

Starting point was the Arduino-ESP32 core's own board variant
(`variants/waveshare_esp32_s3_touch_amoled_143/pins_arduino.h`, shared with the 1.64), then
confirmed on hardware:

- I2C scan on 47/48 answers `0x51` (PCF85063) + `0x6B` (QMI8658) + `0x38` (FT3168, chip-id
  register `0xA3` reads `0x64`).
- Panel drives correctly on CS=9 / SCK=10 / D0–D3=11–14 / RST=21.
- Column gap dialled in with a 1px nudge tool — a full frame composed in PSRAM and blitted in
  one aligned window, so a 1px step really is 1px. 6 centres it; 7 and 8 visibly overshoot.
  (A coarser test card first suggested 0; a 6px-thick ring simply cannot resolve a 6px shift.)
- Touch orientation verified by an on-screen dot tracking a fingertip — raw coordinates map
  straight through, no mirroring, unlike the 1.75.

## Testing

On hardware: panel, touch and swipe between views, IMU, RTC (incl. NTP save and reseed on
boot), WiFi, captive portal, live ADS-B feed, weather, RainViewer radar and EUMETSAT cloud
imagery all exercised over an extended run.

Both envs build clean, and `tests/run_host_tests.sh` passes.

## Deliberately left out

- **Battery reporting is off on the 1.43.** There is a divided battery voltage on GPIO 4, but
  the divider ratio isn't documented, so the firmware reports "no battery" rather than an
  invented percentage. `PIN_BAT_ADC` is recorded in the header for whoever wants to calibrate it.
- **The browser flasher still installs the 1.75 build only.** Adding board selection needs a UI
  change plus a second manifest in `web/flash/`. Release CI does build and attach both (the 1.75
  keeps the unsuffixed filenames; the 1.43 gets an `-amoled143` suffix), and the release notes
  spell out which file is which.
- **QSPI stays at the vendor's 40 MHz** on the 1.43. The 1.75 runs 80; I didn't verify 80 here,
  so I didn't claim it.

## Notes for you

- I bumped `FW_VERSION` to **1.4.0**. 

- `docs/HARDWARE.md` and `docs/SETUP.md` had gone stale (they still described the QSPI/I2C pins
  as unconfirmed `-1` placeholders). They're updated for both boards, with an "Adding another
  board" checklist so the next port has a path to follow.
