### PR TITLE
Fix ADS-B feed: User-Agent never sent, provider pacing, chunked responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A live **ADS-B aircraft radar** for the **Waveshare ESP32-S3-Touch-AMOLED-1.75**
 
 ## Features
 
-- **Live traffic** from [airplanes.live](https://airplanes.live) (free, non-commercial; fallback adsb.lol), updated every couple of seconds. Memory-safe streaming parser with a hard aircraft cap.
+- **Live traffic** from [airplanes.live](https://airplanes.live), [adsb.fi](https://adsb.fi/) and [adsb.lol](https://adsb.lol) (free, non-commercial), updated every couple of seconds. Each provider is paced independently, so one refusing or rate-limiting does not stop the feed. Memory-safe streaming parser with a hard aircraft cap.
 - **Four themes** (long-press the screen to cycle, or pick on the web; remembered across reboots):
   - **Phosphor** — green-on-black radar scope: rings, animated sweep, aircraft glyphs rotated by heading and color-coded by altitude, fading trails, emergency halo.
   - **Orb** — green gradient + grid scope: the 7 nearest aircraft as yellow orbs emitting waves, off-range traffic as edge arrows pointing its way, orange target rings.

--- a/docs/DATA_SOURCE.md
+++ b/docs/DATA_SOURCE.md
@@ -64,6 +64,13 @@ Set the `User-Agent` with `HTTPClient::setUserAgent()`. **`addHeader("User-Agent
 silently ignored** — Arduino keeps that header on an internal "handled by code" list, so the
 request goes out as the default `ESP32HTTPClient` and providers refuse it.
 
+Request with `HTTPClient::useHTTP10(true)`. We stream-parse straight off `http.getStream()`,
+and that is the **raw socket** — Arduino only de-chunks inside `writeToStream()`/`getString()`.
+adsb.fi replies `Transfer-Encoding: chunked` (adsb.lol sends `Content-Length`), so without
+this ArduinoJson reads the hex chunk-size line first, parses `4000` as a valid JSON number,
+and returns success with no `ac` key: a 200 that silently yields no aircraft. HTTP/1.0 has no
+chunked encoding, so the body is Content-Length- or close-delimited and streams correctly.
+
 ### Not used: OpenSky
 Now requires OAuth2 client-credentials and has tighter anonymous limits — awkward for an always-on embedded device. Keep as a documented alternative only.
 

--- a/docs/DATA_SOURCE.md
+++ b/docs/DATA_SOURCE.md
@@ -3,6 +3,11 @@
 ## Primary: airplanes.live (free, no key)
 Independent ADS-B/MLAT aggregator. **Educational / non-commercial use only** — fits this project. Be a good citizen: poll every 1–2 s max, send a descriptive `User-Agent`.
 
+> **Access now requires prior approval.** Unapproved clients get `403` with
+> *"Please contact us at contact@airplanes.live. Your email MUST include any links, a
+> description of the project, and any information you deem appropriate."* Until that is
+> granted the firmware parks this provider and runs on the two below.
+
 ### Endpoint (position + radius)
 ```
 GET https://api.airplanes.live/v2/point/{lat}/{lon}/{radius_nm}
@@ -28,8 +33,36 @@ JSON object; the aircraft list is under key **`ac`** (older/raw readsb files use
 | `t` / `type`   | aircraft type (e.g. B738) when present   | detail card |
 | `dbFlags`      | bitfield (military, etc.)                | "interesting" alerts |
 
+### Second: adsb.fi (opendata)
+Same readsb `ac` payload, **different URL shape**:
+`GET https://opendata.adsb.fi/api/v3/lat/{lat}/lon/{lon}/dist/{radius_nm}` (max 250 NM).
+
+Rate limit is documented and fixed at **1 request per second** for the public endpoints,
+which makes it the most predictable of the three.
+
+> **Attribution is required.** adsb.fi ask that you *"cite adsb.fi and include a link to our
+> home page"*, and the service is for **personal, non-commercial use only**, provided as-is
+> without warranty. Home page: <https://adsb.fi/>. Keep that credit in the README and in any
+> listing (MakerWorld etc.) that ships this firmware.
+
 ### Fallback: adsb.lol
 Same readsb format. `GET https://api.adsb.lol/v2/point/{lat}/{lon}/{radius_nm}`. Wire it as an automatic failover if airplanes.live errors/times out.
+
+Its rate limits are **dynamic** ("based on the environment load"), so there is no fixed rate
+to code against — the firmware adapts its spacing on each 429 rather than assuming a number.
+adsb.lol also rejects a generic `User-Agent` outright (403 *"User-Agent too generic; include
+valid contact info"*), which is why the UA must carry a project link.
+
+## Provider pacing (how the firmware behaves)
+Providers are tried in order and paced **individually**:
+- **403** — a policy refusal (needs approval, or a rejected User-Agent). Parked for 15 min;
+  retrying it every poll only burns requests and pushes the others over their limits.
+- **429** — too fast. An adaptive minimum spacing doubles on each 429 and eases back after a
+  run of successes. An explicit `Retry-After` wins.
+
+Set the `User-Agent` with `HTTPClient::setUserAgent()`. **`addHeader("User-Agent", ...)` is
+silently ignored** — Arduino keeps that header on an internal "handled by code" list, so the
+request goes out as the default `ESP32HTTPClient` and providers refuse it.
 
 ### Not used: OpenSky
 Now requires OAuth2 client-credentials and has tighter anonymous limits — awkward for an always-on embedded device. Keep as a documented alternative only.

--- a/src/adsb_client.cpp
+++ b/src/adsb_client.cpp
@@ -55,11 +55,16 @@ bool AdsbClient::poll(std::vector<Aircraft>& out) {
     if (WiFi.status() != WL_CONNECTED) return false;
     // Try each independent provider once. Retrying the primary immediately can violate its
     // one-request-per-second limit and adds another full timeout to an already slow failure.
-    if (fetchFrom(ADSB_PRIMARY_HOST, out)) return true;
-    return fetchFrom(ADSB_FALLBACK_HOST, out);
+    // A provider in cooldown is skipped entirely: when the primary is hard-failing, that is
+    // what keeps us from doubling the request rate onto the fallback (and tripping its 429).
+    const bool c0 = cooling(0), c1 = cooling(1);
+    _lastPollSkipped = c0 && c1;              // nothing was asked; not a failure
+    if (!c0 && fetchFrom(ADSB_PRIMARY_HOST, 0, out)) return true;
+    if (!c1 && fetchFrom(ADSB_FALLBACK_HOST, 1, out)) return true;
+    return false;
 }
 
-bool AdsbClient::fetchFrom(const char* host, std::vector<Aircraft>& out) {
+bool AdsbClient::fetchFrom(const char* host, int slot, std::vector<Aircraft>& out) {
     const double nm = _rangeKm * 0.539957;            // km -> nautical miles (API radius unit)
     char url[160];
     snprintf(url, sizeof(url), "https://%s/v2/point/%.4f/%.4f/%.0f", host, _lat, _lon, nm);
@@ -71,23 +76,73 @@ bool AdsbClient::fetchFrom(const char* host, std::vector<Aircraft>& out) {
     // client.setCACert(ROOT_CA_PEM);                  // production: pin the root CA
 #endif
 
+    _lastAttemptMs[slot] = millis();
+
     HTTPClient http;
     http.setReuse(false);
     http.setConnectTimeout(6000);    // fail reasonably fast: a slow host must not block the
     http.setTimeout(8000);           // task (and the user's route/photo lookups) for too long
     if (!http.begin(client, url)) { Serial.printf("[adsb] begin failed (%s)\n", host); return false; }
-    http.addHeader("User-Agent", ADSB_USER_AGENT);
+    // MUST be setUserAgent(): addHeader() silently drops User-Agent (it is on
+    // HTTPClient's "handled by code" list), leaving the default "ESP32HTTPClient".
+    http.setUserAgent(ADSB_USER_AGENT);
     http.addHeader("Accept", "application/json");
+    const char* wanted[] = { "Retry-After" };
+    http.collectHeaders(wanted, 1);
 
     const int code = http.GET();
     if (code != 200) {
         char tls[128] = "";
         const int tlsCode = client.lastError(tls, sizeof(tls));
+        // Log a bounded slice of the error body. Providers explain themselves here
+        // ("contact us for access", "rate limited", ...) and throwing it away turns an
+        // actionable message into a bare status code. Bounded + time-capped so a hostile
+        // or hanging response can never stall the poll task.
+        char body[161] = "";
+        if (code > 0) {
+            NetworkClient& es = http.getStream();
+            size_t n = 0;
+            const uint32_t t0 = millis();
+            while (n < sizeof(body) - 1 && (millis() - t0) < 500) {
+                if (!es.available()) {
+                    if (!es.connected()) break;
+                    delay(5);
+                    continue;
+                }
+                const int c = es.read();
+                if (c < 0) break;
+                body[n++] = (c == '\r' || c == '\n') ? ' ' : (char)c;
+            }
+            body[n] = '\0';
+        }
         Serial.printf("[adsb] HTTP %d (%s) tls=%d '%s' heap=%u largest=%u psram=%u\n",
                       code, host, tlsCode, tls,
                       (unsigned)ESP.getFreeHeap(),
                       (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL),
                       (unsigned)ESP.getFreePsram());
+        if (body[0]) Serial.printf("[adsb]   body: %s\n", body);
+
+        if (code == 403) {
+            // Policy refusal: park it. Announce once, not on every poll.
+            _cooldownUntil[slot] = millis() + ADSB_COOLDOWN_403_MS;
+            if (!_cooldownLogged[slot]) {
+                Serial.printf("[adsb] %s parked for %us after HTTP 403\n",
+                              host, (unsigned)(ADSB_COOLDOWN_403_MS / 1000));
+                _cooldownLogged[slot] = true;
+            }
+        } else if (code == 429) {
+            _okStreak[slot] = 0;
+            const long ra = http.header("Retry-After").toInt();
+            if (ra > 0) _cooldownUntil[slot] = millis() + (uint32_t)ra * 1000UL;
+            // Back off multiplicatively; the limit is dynamic, so probe for what sticks.
+            uint32_t sp = _spacingMs[slot] ? _spacingMs[slot] * 2 : ADSB_SPACING_STEP_MS;
+            if (sp > ADSB_SPACING_MAX_MS) sp = ADSB_SPACING_MAX_MS;
+            if (sp != _spacingMs[slot]) {
+                _spacingMs[slot] = sp;
+                Serial.printf("[adsb] %s rate-limited; spacing requests %us apart\n",
+                              host, (unsigned)(sp / 1000));
+            }
+        }
         http.end(); return false;
     }
 
@@ -119,6 +174,18 @@ bool AdsbClient::fetchFrom(const char* host, std::vector<Aircraft>& out) {
         return false;
     }
     http.end();
+    _cooldownLogged[slot] = false;      // healthy again: allow a future park to be announced
+
+    // Ease the imposed gap back down after a sustained good run, so a one-off busy period
+    // upstream does not slow us permanently. Additive decrease against the multiplicative
+    // increase above: quick to back off, cautious to speed up.
+    if (_spacingMs[slot] && ++_okStreak[slot] >= ADSB_SPACING_EASE_OKS) {
+        _okStreak[slot] = 0;
+        _spacingMs[slot] = (_spacingMs[slot] > ADSB_SPACING_STEP_MS)
+                             ? _spacingMs[slot] - ADSB_SPACING_STEP_MS : 0;
+        Serial.printf("[adsb] %s steady; spacing eased to %us\n",
+                      host, (unsigned)(_spacingMs[slot] / 1000));
+    }
 
     JsonArrayConst arr = doc["ac"].as<JsonArrayConst>();
     if (arr.isNull()) arr = doc["aircraft"].as<JsonArrayConst>();

--- a/src/adsb_client.cpp
+++ b/src/adsb_client.cpp
@@ -51,23 +51,42 @@ void AdsbClient::begin(double homeLat, double homeLon, float rangeKm) {
     _lat = homeLat; _lon = homeLon; _rangeKm = rangeKm;
 }
 
+// Independent providers, tried in order. Same readsb payload, different URL shapes.
+// Order matters: airplanes.live stays first so an approved key is used when available
+// (it parks itself in seconds if not), then adsb.fi, whose 1 req/s limit is documented
+// and fixed, then adsb.lol, whose limits are dynamic and throttle hardest.
+struct AdsbProvider {
+    const char* host;
+    const char* pathFmt;   // lat, lon, radius-in-nm
+};
+static const AdsbProvider kProviders[ADSB_PROVIDER_COUNT] = {
+    { ADSB_PRIMARY_HOST,  "/v2/point/%.4f/%.4f/%.0f"        },
+    { ADSB_OPENDATA_HOST, "/api/v3/lat/%.4f/lon/%.4f/dist/%.0f" },
+    { ADSB_FALLBACK_HOST, "/v2/point/%.4f/%.4f/%.0f"        },
+};
+
 bool AdsbClient::poll(std::vector<Aircraft>& out) {
     if (WiFi.status() != WL_CONNECTED) return false;
-    // Try each independent provider once. Retrying the primary immediately can violate its
-    // one-request-per-second limit and adds another full timeout to an already slow failure.
-    // A provider in cooldown is skipped entirely: when the primary is hard-failing, that is
-    // what keeps us from doubling the request rate onto the fallback (and tripping its 429).
-    const bool c0 = cooling(0), c1 = cooling(1);
-    _lastPollSkipped = c0 && c1;              // nothing was asked; not a failure
-    if (!c0 && fetchFrom(ADSB_PRIMARY_HOST, 0, out)) return true;
-    if (!c1 && fetchFrom(ADSB_FALLBACK_HOST, 1, out)) return true;
+    // Try each independent provider once, skipping any that is parked or still inside its
+    // spacing window. Retrying a hard-failing provider every poll achieves nothing and just
+    // pushes the surviving ones over their own limits.
+    bool askedSomeone = false;
+    for (int i = 0; i < ADSB_PROVIDER_COUNT; ++i) {
+        if (cooling(i)) continue;
+        askedSomeone = true;
+        if (fetchFrom(i, out)) { _lastPollSkipped = false; return true; }
+    }
+    _lastPollSkipped = !askedSomeone;          // nothing was asked; not a failure
     return false;
 }
 
-bool AdsbClient::fetchFrom(const char* host, int slot, std::vector<Aircraft>& out) {
+bool AdsbClient::fetchFrom(int slot, std::vector<Aircraft>& out) {
+    const char* host = kProviders[slot].host;
     const double nm = _rangeKm * 0.539957;            // km -> nautical miles (API radius unit)
+    char path[96];
+    snprintf(path, sizeof(path), kProviders[slot].pathFmt, _lat, _lon, nm);
     char url[160];
-    snprintf(url, sizeof(url), "https://%s/v2/point/%.4f/%.4f/%.0f", host, _lat, _lon, nm);
+    snprintf(url, sizeof(url), "https://%s%s", host, path);
 
     WiFiClientSecure client;
 #if ADSB_HTTPS_INSECURE

--- a/src/adsb_client.cpp
+++ b/src/adsb_client.cpp
@@ -99,6 +99,16 @@ bool AdsbClient::fetchFrom(int slot, std::vector<Aircraft>& out) {
 
     HTTPClient http;
     http.setReuse(false);
+    // Ask in HTTP/1.0, which has no chunked transfer encoding.
+    //
+    // This matters because we stream-parse straight off http.getStream(), and that is the
+    // RAW socket: Arduino's HTTPClient only de-chunks inside writeToStream()/getString().
+    // Against a chunked server (adsb.fi is one; adsb.lol sends Content-Length) ArduinoJson
+    // therefore saw the hex chunk-size line first, parsed "4000" as a perfectly good JSON
+    // number, and reported success with no "ac" key -- a 200 that silently yielded no
+    // aircraft. HTTP/1.0 makes the body either Content-Length- or close-delimited, both of
+    // which the streaming parser handles. Verified against all three providers.
+    http.useHTTP10(true);
     http.setConnectTimeout(6000);    // fail reasonably fast: a slow host must not block the
     http.setTimeout(8000);           // task (and the user's route/photo lookups) for too long
     if (!http.begin(client, url)) { Serial.printf("[adsb] begin failed (%s)\n", host); return false; }
@@ -194,6 +204,7 @@ bool AdsbClient::fetchFrom(int slot, std::vector<Aircraft>& out) {
     }
     http.end();
     _cooldownLogged[slot] = false;      // healthy again: allow a future park to be announced
+    _lastHost = host;                   // so the caller can say who served the data
 
     // Ease the imposed gap back down after a sustained good run, so a one-off busy period
     // upstream does not slow us permanently. Additive decrease against the multiplicative
@@ -208,7 +219,13 @@ bool AdsbClient::fetchFrom(int slot, std::vector<Aircraft>& out) {
 
     JsonArrayConst arr = doc["ac"].as<JsonArrayConst>();
     if (arr.isNull()) arr = doc["aircraft"].as<JsonArrayConst>();
-    if (arr.isNull()) return false;
+    if (arr.isNull()) {
+        // Was silent, which made a provider that answers 200 with an unexpected shape
+        // indistinguishable from one that is never tried at all.
+        Serial.printf("[adsb] %s: 200 but no aircraft array (expected=%d read=%u)\n",
+                      host, expectedBytes, (unsigned)jsonStream.bytesRead());
+        return false;
+    }
 
     // Keep the ADSB_MAX_AIRCRAFT *nearest* aircraft (not just the first ones the feed happens to
     // list), so busy areas still show the traffic closest to you. We gate by distance BEFORE

--- a/src/adsb_client.h
+++ b/src/adsb_client.h
@@ -2,6 +2,7 @@
 // Fetches nearby aircraft from airplanes.live (fallback adsb.lol) and parses
 // the readsb JSON into a vector<Aircraft>. See docs/DATA_SOURCE.md.
 #include <vector>
+#include <Arduino.h>
 #include "aircraft.h"
 
 class AdsbClient {
@@ -20,8 +21,41 @@ public:
 
     uint32_t lastOkMs() const { return _lastOkMs; }
 
+    // True when the last poll() issued no request at all because every provider was
+    // parked or still inside its adaptive spacing window. That is deliberate pacing,
+    // not an outage, and the caller must not treat it as a failed fetch.
+    bool lastPollSkipped() const { return _lastPollSkipped; }
+
 private:
-    bool fetchFrom(const char* host, std::vector<Aircraft>& out);   // one host, one attempt
+    // `slot` indexes the per-provider cooldown below: 0 = primary, 1 = fallback.
+    bool fetchFrom(const char* host, int slot, std::vector<Aircraft>& out);
+
+    // Per-provider pacing. Two separate mechanisms, because the two failures differ:
+    //
+    //   403 -> a policy refusal (needs approval, or a User-Agent they reject). It will not
+    //          clear in seconds, so the provider is PARKED outright. Retrying it every poll
+    //          only burns a request and doubles the rate onto the surviving provider.
+    //
+    //   429 -> we are simply too fast. adsb.lol documents its limits as "dynamic based on
+    //          the environment load", so there is no fixed rate to hard-code. Instead keep
+    //          an adaptive minimum SPACING per provider: double it on every 429, and ease
+    //          it back down after a run of successes. That settles on the fastest rate the
+    //          provider will currently tolerate, instead of flapping between full speed and
+    //          a dead stop. An explicit Retry-After still wins and parks us for that long.
+    //
+    // All time comparisons are millis()-rollover-safe via signed subtraction.
+    uint32_t _cooldownUntil[2]  = {0, 0};
+    uint32_t _spacingMs[2]      = {0, 0};
+    uint32_t _lastAttemptMs[2]  = {0, 0};
+    uint16_t _okStreak[2]       = {0, 0};
+    bool     _cooldownLogged[2] = {false, false};
+
+    bool cooling(int slot) const {
+        if ((int32_t)(_cooldownUntil[slot] - millis()) > 0) return true;
+        if (_spacingMs[slot] &&
+            (int32_t)(millis() - _lastAttemptMs[slot]) < (int32_t)_spacingMs[slot]) return true;
+        return false;
+    }
 
     double _lat = 0, _lon = 0;
     float  _rangeKm = 15.0f;
@@ -30,4 +64,5 @@ private:
     float  _maxAltFt = 0.0f;
     bool   _milOnly = false;
     uint32_t _lastOkMs = 0;
+    bool     _lastPollSkipped = false;
 };

--- a/src/adsb_client.h
+++ b/src/adsb_client.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <Arduino.h>
 #include "aircraft.h"
+#include "config.h"
 
 class AdsbClient {
 public:
@@ -27,8 +28,8 @@ public:
     bool lastPollSkipped() const { return _lastPollSkipped; }
 
 private:
-    // `slot` indexes the per-provider cooldown below: 0 = primary, 1 = fallback.
-    bool fetchFrom(const char* host, int slot, std::vector<Aircraft>& out);
+    // `slot` indexes both the provider table in adsb_client.cpp and the pacing state below.
+    bool fetchFrom(int slot, std::vector<Aircraft>& out);
 
     // Per-provider pacing. Two separate mechanisms, because the two failures differ:
     //
@@ -44,11 +45,11 @@ private:
     //          a dead stop. An explicit Retry-After still wins and parks us for that long.
     //
     // All time comparisons are millis()-rollover-safe via signed subtraction.
-    uint32_t _cooldownUntil[2]  = {0, 0};
-    uint32_t _spacingMs[2]      = {0, 0};
-    uint32_t _lastAttemptMs[2]  = {0, 0};
-    uint16_t _okStreak[2]       = {0, 0};
-    bool     _cooldownLogged[2] = {false, false};
+    uint32_t _cooldownUntil[ADSB_PROVIDER_COUNT]  = {0};
+    uint32_t _spacingMs[ADSB_PROVIDER_COUNT]      = {0};
+    uint32_t _lastAttemptMs[ADSB_PROVIDER_COUNT]  = {0};
+    uint16_t _okStreak[ADSB_PROVIDER_COUNT]       = {0};
+    bool     _cooldownLogged[ADSB_PROVIDER_COUNT] = {false};
 
     bool cooling(int slot) const {
         if ((int32_t)(_cooldownUntil[slot] - millis()) > 0) return true;

--- a/src/adsb_client.h
+++ b/src/adsb_client.h
@@ -27,6 +27,9 @@ public:
     // not an outage, and the caller must not treat it as a failed fetch.
     bool lastPollSkipped() const { return _lastPollSkipped; }
 
+    // Which provider served the most recent successful fetch.
+    const char* lastHost() const { return _lastHost ? _lastHost : "?"; }
+
 private:
     // `slot` indexes both the provider table in adsb_client.cpp and the pacing state below.
     bool fetchFrom(int slot, std::vector<Aircraft>& out);
@@ -66,4 +69,5 @@ private:
     bool   _milOnly = false;
     uint32_t _lastOkMs = 0;
     bool     _lastPollSkipped = false;
+    const char* _lastHost = nullptr;
 };

--- a/src/config.h
+++ b/src/config.h
@@ -46,8 +46,16 @@ static const float RANGE_STEPS_KM[] = {10.0f, 20.0f, 30.0f, 50.0f, 100.0f};
 #define IDLE_DIM_MS         20000          // dim the screen after this long without a touch
 
 // ---------- ADS-B API (free, non-commercial) ----------
+// Providers are tried in this order; each is paced independently (see AdsbClient).
+// All three return the same readsb shape (an "ac" array), but NOT the same URL path,
+// so each carries its own template in the provider table in adsb_client.cpp.
 #define ADSB_PRIMARY_HOST   "api.airplanes.live"   // GET /v2/point/{lat}/{lon}/{radius_nm}
-#define ADSB_FALLBACK_HOST  "api.adsb.lol"          // same readsb format
+                                                    //   now requires prior approval by email
+#define ADSB_OPENDATA_HOST  "opendata.adsb.fi"     // GET /api/v3/lat/{lat}/lon/{lon}/dist/{nm}
+                                                    //   documented 1 req/s; personal use only,
+                                                    //   attribution required (see docs/DATA_SOURCE.md)
+#define ADSB_FALLBACK_HOST  "api.adsb.lol"          // same readsb format; limits are dynamic
+#define ADSB_PROVIDER_COUNT 3
 #define ADSB_USER_AGENT     "CapsuleRadar/1.0 (ESP32-S3 hobby; +https://github.com/socquique/capsule-radar)"
 #define ADSB_HTTPS_INSECURE 1               // 1 = setInsecure() (hobby). 0 = use pinned root CA.
 #define ADSB_MAX_AIRCRAFT   60              // hard cap parsed per poll (protect RAM in busy areas)
@@ -58,7 +66,7 @@ static const float RANGE_STEPS_KM[] = {10.0f, 20.0f, 30.0f, 50.0f, 100.0f};
 #define ADSB_COOLDOWN_403_MS  900000UL      // 15 min park after a policy refusal
 #define ADSB_SPACING_STEP_MS    4000UL      // first extra gap imposed after a 429
 #define ADSB_SPACING_MAX_MS    60000UL      // never space a provider out further than this
-#define ADSB_SPACING_EASE_OKS      10       // successes needed before easing the gap back down
+#define ADSB_SPACING_EASE_OKS       3       // successes needed before easing the gap back down
 #define ADSB_FEED_STALE_MS     60000UL      // no successful fetch for this long -> HUD warning
 
 // ---------- Debug ----------

--- a/src/config.h
+++ b/src/config.h
@@ -51,6 +51,15 @@ static const float RANGE_STEPS_KM[] = {10.0f, 20.0f, 30.0f, 50.0f, 100.0f};
 #define ADSB_USER_AGENT     "CapsuleRadar/1.0 (ESP32-S3 hobby; +https://github.com/socquique/capsule-radar)"
 #define ADSB_HTTPS_INSECURE 1               // 1 = setInsecure() (hobby). 0 = use pinned root CA.
 #define ADSB_MAX_AIRCRAFT   60              // hard cap parsed per poll (protect RAM in busy areas)
+// How long to stop asking a provider that refused us. 403 is a policy refusal (needs
+// approval, or a User-Agent they reject) and will not clear in seconds; 429 just means
+// we were too fast. Without these, a permanently-403 provider is retried every poll,
+// which doubles the request rate onto the surviving provider and trips ITS rate limit.
+#define ADSB_COOLDOWN_403_MS  900000UL      // 15 min park after a policy refusal
+#define ADSB_SPACING_STEP_MS    4000UL      // first extra gap imposed after a 429
+#define ADSB_SPACING_MAX_MS    60000UL      // never space a provider out further than this
+#define ADSB_SPACING_EASE_OKS      10       // successes needed before easing the gap back down
+#define ADSB_FEED_STALE_MS     60000UL      // no successful fetch for this long -> HUD warning
 
 // ---------- Debug ----------
 #define DEBUG_MEM           0               // 1 = print a [mem] heap/fps line every 5s on serial

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,7 @@ static void adsb_task(void*) {
                 // poll() tries the fallback provider after a primary failure; keep the HUD
                 // healthy through isolated misses and warn only after a sustained outage.
                 if (g_adsb.poll(fresh)) {
-                    Serial.printf("[adsb] fetched %u aircraft\n", (unsigned)fresh.size());
+                    Serial.printf("[adsb] fetched %u aircraft from %s\n", (unsigned)fresh.size(), g_adsb.lastHost());
                     failCount = 0;
                     g_feedOk = true;
                     const uint32_t receivedMs = millis();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,6 +182,13 @@ static void adsb_task(void*) {
                             xSemaphoreGive(g_ac_mutex);
                         }
                     }
+                } else if (g_adsb.lastPollSkipped()) {
+                    // Every provider is parked or inside its spacing window: we chose not to
+                    // ask. Logging this each tick would bury the real errors, and counting it
+                    // would show an outage warning for our own politeness. Prolonged silence
+                    // still trips the warning, via the time check rather than a fail count.
+                    if ((int32_t)(nowMs - g_adsb.lastOkMs()) > (int32_t)ADSB_FEED_STALE_MS)
+                        g_feedOk = false;
                 } else {
                     Serial.println("[adsb] poll failed");
                     if (++failCount >= 5) g_feedOk = false;   // sustained outage -> HUD warning

--- a/src/route_client.cpp
+++ b/src/route_client.cpp
@@ -109,7 +109,9 @@ bool route_fetch(const char *callsign, char *from, size_t fn, char *to, size_t t
     http.setConnectTimeout(3000);   // short: runs on the feed task, don't stall the live poll
     http.setTimeout(6000);
     if (!http.begin(client, url)) return false;
-    http.addHeader("User-Agent", ADSB_USER_AGENT);
+    // MUST be setUserAgent(): addHeader() silently drops User-Agent (it is on
+    // HTTPClient's "handled by code" list), leaving the default "ESP32HTTPClient".
+    http.setUserAgent(ADSB_USER_AGENT);
 
     const int code = http.GET();
     if (code != 200) { http.end(); return false; }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -535,7 +535,14 @@ static void build_weather(void) {
         s_weatherMode == WEATHER_CLOUDS ? "SAT CLOUDS" : "WEATHER");
 }
 
+// Shared by the mode button (on PRESS) and the weather image (on CLICK) -- see the two
+// registrations for why they differ. The debounce keeps a single touch from cycling twice
+// when both could fire, and swallows repeats from a held press.
 static void weather_mode_cb(lv_event_t *) {
+    static uint32_t last = 0;
+    const uint32_t now = lv_tick_get();
+    if (now - last < 250) return;
+    last = now;
     s_weatherMode = (WeatherViewMode)(((int)s_weatherMode + 1) % 3);
     build_weather();
 }
@@ -867,6 +874,17 @@ void ui_create(void) {
 
     // --- weather tile (current conditions + next three days) ---
     lv_obj_t *wp = make_round_panel(s_tileWeather);
+    // The entire view cycles the weather mode: there is nothing else to touch here, and a
+    // 34px pill 18px from the bottom of a ROUND panel is a genuinely hard target -- measured
+    // presses aimed at it landed a few px low, outside it, and read as the button ignoring
+    // you. Everything below is left non-clickable so all taps funnel here.
+    //
+    // CLICKED, not PRESSED: this panel scroll-chains to the tileview, so dragging across it
+    // is how you swipe off the view. On PRESSED every such swipe would also cycle the mode.
+    // Cancel-on-scroll is exactly what a full-screen target wants -- and the finger drift
+    // that made CLICKED unreliable on a small pill no longer matters now position does not.
+    lv_obj_add_flag(wp, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_event_cb(wp, weather_mode_cb, LV_EVENT_CLICKED, nullptr);
     lv_obj_set_style_bg_color(wp, lv_color_black(), 0); // hide square radar-tile bounds on AMOLED
     s_weatherTitle = make_tile_title(wp, "WX RADAR");
     lv_obj_set_style_bg_color(s_weatherTitle, lv_color_black(), 0);
@@ -920,8 +938,8 @@ void ui_create(void) {
     s_wxCanvas = lv_canvas_create(wp);
     lv_obj_set_size(s_wxCanvas, WX_RADAR_SIZE, WX_RADAR_SIZE);
     lv_obj_align(s_wxCanvas, LV_ALIGN_TOP_MID, 0, 52);
-    lv_obj_add_flag(s_wxCanvas, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_add_event_cb(s_wxCanvas, weather_mode_cb, LV_EVENT_CLICKED, nullptr);
+    // Not clickable: taps pass through to the panel, which owns the whole view.
+    lv_obj_clear_flag(s_wxCanvas, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_add_flag(s_wxCanvas, LV_OBJ_FLAG_HIDDEN);
     lv_obj_move_background(s_wxCanvas);
 
@@ -1055,7 +1073,9 @@ void ui_create(void) {
     lv_obj_set_style_border_color(s_weatherModeBtn, UI_GREEN, 0);
     lv_obj_set_style_border_width(s_weatherModeBtn, 1, 0);
     lv_obj_clear_flag(s_weatherModeBtn, LV_OBJ_FLAG_SCROLL_CHAIN);
-    lv_obj_add_event_cb(s_weatherModeBtn, weather_mode_cb, LV_EVENT_CLICKED, nullptr);
+    // Purely a label showing which mode comes next -- the panel handles the tap, so this
+    // must NOT be clickable or it would swallow presses that land on it.
+    lv_obj_clear_flag(s_weatherModeBtn, LV_OBJ_FLAG_CLICKABLE);
     s_weatherModeLbl = lv_label_create(s_weatherModeBtn);
     lv_obj_set_style_text_font(s_weatherModeLbl, F12(), 0);
     lv_obj_set_style_text_color(s_weatherModeLbl, UI_GREEN, 0);

--- a/src/weather_client.cpp
+++ b/src/weather_client.cpp
@@ -28,7 +28,9 @@ bool weather_fetch(double lat, double lon, WeatherSnapshot &out) {
         Serial.println("[weather] HTTP begin failed");
         return false;
     }
-    http.addHeader("User-Agent", ADSB_USER_AGENT);
+    // MUST be setUserAgent(): addHeader() silently drops User-Agent (it is on
+    // HTTPClient's "handled by code" list), leaving the default "ESP32HTTPClient".
+    http.setUserAgent(ADSB_USER_AGENT);
 
     const int status = http.GET();
     if (status != 200) {

--- a/src/wx_radar_client.cpp
+++ b/src/wx_radar_client.cpp
@@ -68,7 +68,9 @@ static bool https_get_string(const char *url, String &body, int timeoutMs) {
     http.setConnectTimeout(3500);
     http.setTimeout(timeoutMs);
     if (!http.begin(client, url)) return false;
-    http.addHeader("User-Agent", ADSB_USER_AGENT);
+    // MUST be setUserAgent(): addHeader() silently drops User-Agent (it is on
+    // HTTPClient's "handled by code" list), leaving the default "ESP32HTTPClient".
+    http.setUserAgent(ADSB_USER_AGENT);
     const int status = http.GET();
     if (status != 200) {
         char tls[128] = "";


### PR DESCRIPTION
The ADS-B feed currently returns nothing. Three causes, chased in order, plus one
unrelated UI fix that came out of the same session (happy to split it out — see the
end).

Everything below was diagnosed and verified on hardware, and each finding is
reproducible from a laptop with `curl`.

## 1. The `User-Agent` header has never actually been sent

`http.addHeader("User-Agent", ...)` is a no-op. Arduino's `HTTPClient` keeps
`User-Agent` on an internal "handled by code" list alongside `Host` and `Connection`,
and `addHeader()` drops it silently. Every request has gone out as the library default
`ESP32HTTPClient`, never as `ADSB_USER_AGENT`.

Harmless while providers tolerated it. adsb.lol no longer does:

```
HTTP 403  User-Agent too generic; include valid contact info.
```

Confirmed by sending that exact default UA from curl and getting back the identical
403 and message, while the project's real UA string returns 200.

Fixed with `setUserAgent()` at all four affected call sites (adsb, weather, route,
wx_radar). Note `photo_client.cpp` already used `setUserAgent`, with a comment saying
planespotters rejects the default UA — the same bug, found and fixed at one site only.

## 2. Providers were retried identically regardless of why they failed

**airplanes.live now requires prior approval** and returns 403 to everyone:

```
{"error": "Please contact us at contact@airplanes.live. Your email MUST include
 any links, a description of the project, and any information you deem appropriate."}
```

So the primary failed on every poll. Retrying it every 2 s achieved nothing and
doubled the request rate onto the fallback, which then started returning 429.

Providers are now paced individually, by failure kind:

- **403** — a policy refusal that will not clear in seconds. Park the provider for
  15 min and announce it once rather than every poll.
- **429** — simply too fast. adsb.lol documents its limits as *"dynamic based on the
  environment load"*, so there is no fixed rate to code against: keep an adaptive
  minimum spacing per provider, doubling on each 429 and easing back after a good run.
  An explicit `Retry-After` still wins.

Measured: spacing converged 4s → 8s → 16s then held with no further 429s, fetching
steadily instead of flapping between full speed and a dead stop.

## 3. Chunked responses were silently parsed as "no aircraft"

Added **adsb.fi** as a third provider — its public limit is documented and fixed at
1 req/s, unlike adsb.lol's dynamic throttling. It appeared to do nothing at all: no
log lines, and every request still fell through to adsb.lol.

It was being asked every poll and failing through the one path with no logging. We
stream-parse straight off `http.getStream()`, which is the **raw socket** — Arduino
only de-chunks inside `writeToStream()`/`getString()`. adsb.fi replies
`Transfer-Encoding: chunked` (adsb.lol sends `Content-Length`), so ArduinoJson was
handed the hex chunk-size line first, parsed `4000` as a perfectly valid JSON number,
returned `Ok`, and found no `ac` key. A 74 KB response arriving as 3 bytes of parsed
content, indistinguishable from a provider that was never tried.

`useHTTP10(true)` removes it at the source: HTTP/1.0 has no chunked encoding, so the
body is Content-Length- or close-delimited and the streaming parser handles both.
Checked against all three providers before and after.

**Result on hardware: 39 fetches in 90 s, mean gap 2.1 s, no 429s, fallback never
touched** — where before it was one fetch every ~30 s.

Related: `net_fetch_psram()` already handled this for image downloads
(`chunked -> small-String fallback`), so the codebase knew about the trap — just not
in `adsb_client`.

## Diagnostics

Non-200 responses now log a bounded slice of the body (160 bytes, 500 ms cap). Both
diagnoses above came straight from those bodies; discarding them turned actionable
messages into a bare status code. The previously silent "200 but no aircraft array"
case is logged too, and the fetch line names the serving provider.

A poll that issues no request because every provider is paced is no longer logged as
`poll failed` nor counted toward the outage warning — that reported our own politeness
as a fault. Prolonged silence still trips the HUD warning, via time since last success.

## 4. Weather view: whole panel cycles the mode

Unrelated to the above. The mode button responded erratically — a few taps worked,
then it seemed to stick for seconds.

Nothing was stuck. Instrumenting the touch controller showed the button occupies
y 414–447 while presses aimed at it landed at y 448–463: consistently a few pixels
low. It is a 34 px target 18 px from the bottom of a **round** panel, where the glass
curves away and the reported contact point sits below where the press looks like it
landed. Misses did nothing, so it read as ignoring you until one happened to land
inside.

There is nothing else to touch on that view, so the whole 462 px panel is now the
target; the button becomes a label showing the next mode. It stays on
`LV_EVENT_CLICKED`, not `PRESSED` — the panel scroll-chains to the tileview, so
dragging across it is how you swipe off the view, and on `PRESSED` every swipe would
also cycle the mode.

## Notes

- **Attribution:** adsb.fi ask to be cited with a link to their home page and are
  personal/non-commercial only. Credited in the README and recorded in
  `docs/DATA_SOURCE.md`, which also now documents the pacing rules, the airplanes.live
  approval requirement, and both HTTPClient traps.
- **airplanes.live access** must be requested by email; the primary will keep parking
  itself until that is granted. Nothing here can fix that.
- Both PlatformIO envs build; `tests/run_host_tests.sh` passes.
- Merges cleanly with #17 (verified locally) — the two are independent.
- **Happy to split** the weather fix into its own PR if you would rather keep this to
  the feed; it was combined only to save you a review round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
